### PR TITLE
doc: integrate description of .strict in vars_select and vars_rename

### DIFF
--- a/R/vars-rename.R
+++ b/R/vars-rename.R
@@ -1,7 +1,5 @@
 #' @export
 #' @rdname vars_select
-#' @param .strict If `TRUE`, will throw an error if you attempt to rename a
-#'   variable that doesn't exist.
 vars_rename <- function(.vars, ..., .strict = TRUE) {
   quos <- quos(...)
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -29,7 +29,7 @@
 #'   calling context.
 #' @param .include,.exclude Character vector of column names to always
 #'   include/exclude.
-#' @param .strict If `TRUE`, will throw an error if you attempt to slect or
+#' @param .strict If `TRUE`, will throw an error if you attempt to select or
 #'   rename a variable that doesn't exist.
 #' @seealso [vars_pull()]
 #' @export

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -29,7 +29,8 @@
 #'   calling context.
 #' @param .include,.exclude Character vector of column names to always
 #'   include/exclude.
-#' @param .strict If `FALSE`, errors about unknown columns are ignored.
+#' @param .strict If `TRUE`, will throw an error if you attempt to slect or
+#'   rename a variable that doesn't exist.
 #' @seealso [vars_pull()]
 #' @export
 #' @keywords internal

--- a/man/vars_select.Rd
+++ b/man/vars_select.Rd
@@ -27,13 +27,11 @@ are evaluated outside that context. This is to prevent accidental
 matching to \code{vars} elements when you refer to variables from the
 calling context.}
 
-\item{.strict}{If \code{TRUE}, will throw an error if you attempt to rename a
-variable that doesn't exist.}
+\item{.strict}{If \code{TRUE}, will throw an error if you attempt to select or
+rename a variable that doesn't exist.}
 
 \item{.include, .exclude}{Character vector of column names to always
 include/exclude.}
-
-\item{.strict}{If \code{FALSE}, errors about unknown columns are ignored.}
 }
 \value{
 A named character vector. Values are existing column names,


### PR DESCRIPTION
vars-rename.R and vars-select.R both describes the `.strict` parameter, and thus the document has description of `.strict` twice.
This PR fixes it.

Note that I did not run `devtools::document` because I use roxygen 6.1.1 whereas the current version of `tiyselect` uses 6.1.0, and also because I got `Error in getDLLRegisteredRoutines.DLLInfo(dll, addNames = FALSE)`

https://github.com/tidyverse/tidyselect/blob/b8c83cc0292e04701bf0a1b892da4bb1aee47ed3/R/vars-rename.R#L3-L4
https://github.com/tidyverse/tidyselect/blob/b8c83cc0292e04701bf0a1b892da4bb1aee47ed3/R/vars-select.R#L32