### PR TITLE
Add better error message for tidyselect helpers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)

--- a/R/vars.R
+++ b/R/vars.R
@@ -80,8 +80,14 @@ poke_vars <- function(vars) {
 }
 #' @rdname poke_vars
 #' @export
-peek_vars <- function() {
-  vars_env$selected %||% abort("No tidyselect variables were registered")
+peek_vars <- function(generic_error = FALSE) {
+  if (is.null(vars_env$selected)) {
+    the_call <- sys.call(sys.parent()) 
+    fun <- as.character(the_call)[1]
+    msg <- sprintf("`%s()` must be used within a *selecting* function", fun)
+    abort(msg)
+  } 
+  vars_env$selected
 }
 
 #' @rdname poke_vars

--- a/R/vars.R
+++ b/R/vars.R
@@ -79,15 +79,22 @@ poke_vars <- function(vars) {
   invisible(old)
 }
 #' @rdname poke_vars
+#' @param fn the name of the function to use in the error message. Defaults to
+#'   `NULL`, which will use the first element of `sys.call(sys.parent())`.
 #' @export
-peek_vars <- function() {
+peek_vars <- function(fn = NULL) {
   if (is.null(vars_env$selected)) {
-    the_call <- sys.call(sys.parent()) 
-    fun <- as.character(the_call)[1]
-    if (fun == "peek_vars") {
-      msg <- "No tidyselect variables were registered."
+    if (is.null(fn)) {
+      the_call <- sys.call(sys.parent())
+      fn <- the_call[[1]]
     } else {
-      msg <- sprintf("`%s()` must be used within a *selecting* function", fun)
+      fn <- as.symbol(fn)
+    }
+    if (is.symbol(fn) && !identical(fn, as.symbol('peek_vars'))) {
+      fn  <- as.character(fn)
+      msg <- sprintf("`%s()` must be used within a *selecting* function", fn)
+    } else {
+      msg <- "No tidyselect variables were registered."
     }
     abort(msg)
   } 

--- a/R/vars.R
+++ b/R/vars.R
@@ -80,7 +80,7 @@ poke_vars <- function(vars) {
 }
 #' @rdname poke_vars
 #' @export
-peek_vars <- function(generic_error = FALSE) {
+peek_vars <- function() {
   if (is.null(vars_env$selected)) {
     the_call <- sys.call(sys.parent()) 
     fun <- as.character(the_call)[1]

--- a/R/vars.R
+++ b/R/vars.R
@@ -90,7 +90,7 @@ peek_vars <- function(fn = NULL) {
     } else {
       fn <- as.symbol(fn)
     }
-    if (is.symbol(fn) && !identical(fn, as.symbol('peek_vars'))) {
+    if (is.symbol(fn)) {
       fn  <- as.character(fn)
       msg <- sprintf("`%s()` must be used within a *selecting* function", fn)
     } else {

--- a/R/vars.R
+++ b/R/vars.R
@@ -84,7 +84,11 @@ peek_vars <- function() {
   if (is.null(vars_env$selected)) {
     the_call <- sys.call(sys.parent()) 
     fun <- as.character(the_call)[1]
-    msg <- sprintf("`%s()` must be used within a *selecting* function", fun)
+    if (fun == "peek_vars") {
+      msg <- "No tidyselect variables were registered."
+    } else {
+      msg <- sprintf("`%s()` must be used within a *selecting* function", fun)
+    }
     abort(msg)
   } 
   vars_env$selected

--- a/man/poke_vars.Rd
+++ b/man/poke_vars.Rd
@@ -10,7 +10,7 @@
 \usage{
 poke_vars(vars)
 
-peek_vars()
+peek_vars(fn = NULL)
 
 scoped_vars(vars, frame = caller_env())
 
@@ -20,6 +20,9 @@ has_vars()
 }
 \arguments{
 \item{vars}{A character vector of variable names.}
+
+\item{fn}{the name of the function to use in the error message. Defaults to
+\code{NULL}, which will use the first element of \code{sys.call(sys.parent())}.}
 
 \item{frame}{The frame environment where the exit hook for
 restoring the old variables should be registered.}

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -27,8 +27,9 @@ test_that("if the parent call is not a symbol, then return generic", {
 })
 
 test_that("if the fn is peek_vars, then return generic", {
-  expect_error(peek_vars('peek_vars'), "No tidyselect variables were registered.")
+  expect_error(peek_vars('peek_vars'), "`peek_vars()` must be used within a *selecting* function", fixed = TRUE)
 })
+
 
 test_that("peek_vars can take a custom function name", {
   expect_error(peek_vars("z"), "`z()` must be used", fixed = TRUE)  

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -1,16 +1,37 @@
 context("select helpers")
 
 test_that("no set variables throws error", {
-  expect_error(starts_with("z"), ".starts_with... must be used")
-  expect_error(one_of("z"), ".one_of... must be used")
+  expect_error(starts_with("z"), "`starts_with()` must be used within a *selecting* function", fixed = TRUE)
+  expect_error(one_of("z"), "`one_of()` must be used within a *selecting* function", fixed = TRUE)
 })
 
 test_that("no set variables throws error from the correct function", {
-  expect_error(one_of(starts_with("z")), ".starts_with... must be used")
+  expect_error(one_of(starts_with("z")), "`starts_with()` must be used within a *selecting* function", fixed = TRUE)
 })
 
-test_that("no set variables from peek_vars() directly will give the original message", {
-  expect_error(peek_vars(), "No tidyselect variables were registered.")
+
+# ZNK 2019-07-08: This is a weird situation where a NULL input gets peek_vars()
+# to get its caller. The problem with this is that testthat wraps everything in
+# the test environment, so peek_vars() then returns the error message
+# `eval()` must be used within a *selecting* function.... which doesn't really
+# make a whole lot of sense ಠ_ಠ
+#
+# These next two tests do two things to actually test the path of the code:
+#
+# 1. test if the first part of the call is not a symbol
+# 2. test if fn is equal to `peek_vars`, which would happen in a 
+#    global environment setting.
+test_that("if the parent call is not a symbol, then return generic", {
+  pv <- function() function() peek_vars()
+  expect_error(pv()(), "No tidyselect variables were registered.")
+})
+
+test_that("if the fn is peek_vars, then return generic", {
+  expect_error(peek_vars('peek_vars'), "No tidyselect variables were registered.")
+})
+
+test_that("peek_vars can take a custom function name", {
+  expect_error(peek_vars("z"), "`z()` must be used", fixed = TRUE)  
 })
 
 test_that("failed match removes all columns", {

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -1,7 +1,12 @@
 context("select helpers")
 
-test_that("no set variables throws warning", {
-  expect_error(starts_with("z"), "No tidyselect variables were registered")
+test_that("no set variables throws error", {
+  expect_error(starts_with("z"), ".starts_with... must be used")
+  expect_error(one_of("z"), ".one_of... must be used")
+})
+
+test_that("no set variables throws error from the correct function", {
+  expect_error(one_of(starts_with("z")), ".starts_with... must be used")
 })
 
 test_that("failed match removes all columns", {

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -9,6 +9,10 @@ test_that("no set variables throws error from the correct function", {
   expect_error(one_of(starts_with("z")), ".starts_with... must be used")
 })
 
+test_that("no set variables from peek_vars() directly will give the original message", {
+  expect_error(peek_vars(), "No tidyselect variables were registered.")
+})
+
 test_that("failed match removes all columns", {
   scoped_vars(c("x", "y"))
 


### PR DESCRIPTION
This will fix #73 when merged.

I found that the message "No tidyselect variables were registered." came from `peek_vars()`, which triggered this when there were (understandably) no vars registered in the `vars_env`. 

This now throws better errors like so:

``` r
library("tidyselect")
starts_with("z")
#> `starts_with()` must be used within a *selecting* function
peek_vars()
#> No tidyselect variables were registered.
```

<sup>Created on 2019-07-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Note that I am unsure of where an option to override the error would go: in the `peek_vars()` or in the helpers?