### PR TITLE
Add pkgdown site to DESCRIPTION URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,5 @@ LazyData: true
 ByteCompile: true
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
-URL: https://github.com/r-lib/tidyselect
+URL: https://tidyselect.r-lib.org, https://github.com/r-lib/tidyselect
 BugReports: https://github.com/r-lib/tidyselect/issues


### PR DESCRIPTION
This should make it possible for us to link directly to the tidyselect site from other package documentation (e.g. see https://github.com/tidyverse/dplyr/issues/4529).