### PR TITLE
Support duplicate variables in `vars_select()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,8 @@ Suggests:
     covr,
     dplyr,
     testthat
+remotes:
+    r-lib/testthat
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,9 +43,7 @@
   only the last one is taken into account (#52). The warning inherits
   from `tidyselect_warning_duplicate_renaming`.
 
-* `vars_select()` now supports duplicate variables (#94). They are
-  ignored if not part of the selection. Otherwise, they are repaired
-  to make them unique.
+* `vars_select()` now ignores existing duplicate variables (#94).
 
 * `one_of()` now always coerces its input to a character, or fails. Similary,
   `vars_select()` now supports unquoting S3 vectors.

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,7 +45,9 @@
 
 * `vars_select()` now ignores existing duplicate variables (#94). It
   fails if user attempts to rename to an existing variable, or if
-  different variables are renamed to the same name.
+  different variables are renamed to the same name. The errors inherit
+  from `tidyselect_error_rename_to_existing` or
+  `tidyselect_error_rename_to_same` respectively.
 
 * `one_of()` now always coerces its input to a character, or fails. Similary,
   `vars_select()` now supports unquoting S3 vectors.

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,7 +43,9 @@
   only the last one is taken into account (#52). The warning inherits
   from `tidyselect_warning_duplicate_renaming`.
 
-* `vars_select()` now ignores existing duplicate variables (#94).
+* `vars_select()` now ignores existing duplicate variables (#94). It
+  fails if user attempts to rename to an existing variable, or if
+  different variables are renamed to the same name.
 
 * `one_of()` now always coerces its input to a character, or fails. Similary,
   `vars_select()` now supports unquoting S3 vectors.

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,10 @@
   only the last one is taken into account (#52). The warning inherits
   from `tidyselect_warning_duplicate_renaming`.
 
+* `vars_select()` now supports duplicate variables (#94). They are
+  ignored if not part of the selection. Otherwise, they are repaired
+  to make them unique.
+
 * `one_of()` now always coerces its input to a character, or fails. Similary,
   `vars_select()` now supports unquoting S3 vectors.
 

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -154,8 +154,13 @@ last_col <- function(offset = 0L, vars = peek_vars()) {
 }
 
 match_vars <- function(needle, haystack) {
-  x <- match(needle, haystack)
-  x[!is.na(x)]
+  if (vctrs::vec_duplicate_any(haystack)) {
+    x <- map(needle, ~ which(. == haystack))
+    x <- vctrs::vec_c(!!!x)
+  } else {
+    x <- vctrs::vec_match(needle, haystack)
+    x[!is.na(x)]
+  }
 }
 
 grep_vars <- function(needle, haystack, ...) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -105,3 +105,7 @@ vec_is_coercible <- function(x, to, ..., x_arg = "x", to_arg = "to") {
 last <- function(x) {
   x[[length(x)]]
 }
+
+str_compact <- function(x) {
+  x[x != ""]
+}

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -226,7 +226,7 @@ inds_combine <- function(vars, inds) {
   walk(inds, ind_check)
   first_negative <- length(inds) && length(inds[[1]]) && inds[[1]][[1]] < 0
 
-  inds <- vctrs::vec_c(!!!inds, .ptype = integer(), .name_spec = inds_name_spec)
+  inds <- vctrs::vec_c(!!!inds, .ptype = integer(), .name_spec = "{outer}{inner}")
   inds <- inds[inds != 0]
 
   if (first_negative) {
@@ -265,14 +265,6 @@ inds_combine <- function(vars, inds) {
 
   names(incl)[unnamed] <- unnamed_vars
   incl
-}
-
-# The caller should deal with duplicates if `outer` is length > 1
-inds_name_spec <- function(outer, inner) {
-  if (!is_integer(inner)) {
-    abort("Internal error: Unexpected inner names in `inds_combine()`.")
-  }
-  outer
 }
 
 inds_unique <- function(x, vars) {

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -357,12 +357,13 @@ vars_select_eval <- function(vars, quos) {
   # Peek validated variables
   vars <- peek_vars()
 
-  # Create data mask
-  empty_names <- are_empty_name(vars)
-  bottom_data <- set_names(seq_along(vars), vars)[!empty_names]
+  vars_split <- vctrs::vec_split(seq_along(vars), vars)
+
+  # We are intentionally lenient towards partially named inputs
+  vars_split <- vctrs::vec_slice(vars_split, !are_empty_name(vars_split$key))
 
   top <- env()
-  bottom <- env(top, !!!bottom_data)
+  bottom <- env(top, !!!set_names(vars_split$val, vars_split$key))
   data_mask <- new_data_mask(bottom, top)
   data_mask$.data <- as_data_pronoun(data_mask)
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -252,8 +252,18 @@ inds_combine <- function(vars, inds) {
 
   names(incl) <- names2(incl)
   unnamed <- names(incl) == ""
-  names(incl)[unnamed] <- vars[incl[unnamed]]
 
+  renamers <- names(incl)[!unnamed]
+  if (vctrs::vec_duplicate_any(renamers)) {
+    abort("Can't rename different columns to the same column name.")
+  }
+
+  unnamed_vars <- vars[incl[unnamed]]
+  if (any(vctrs::vec_in(renamers, unnamed_vars))) {
+    abort("Can't rename column to an existing column name.")
+  }
+
+  names(incl)[unnamed] <- unnamed_vars
   incl
 }
 
@@ -279,8 +289,7 @@ inds_unique <- function(x, vars) {
 }
 
 ind_last_name <- function(x, vars) {
-  names <- names(x)
-  names <- names[names != ""]
+  names <- str_compact(names(x))
 
   if (length(names) == 0) {
     return("")

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -47,6 +47,14 @@
 #'   reasons there can only be one target name. If the same variable
 #'   is renamed to different names, tidyselect issues this warning.
 #'
+#' `vars_select()` signals the following conditions.
+#'
+#' * `tidyselect_error_rename_to_same`: Renaming multiple variables to
+#'   the same name is an error.
+#'
+#' * `tidyselect_error_rename_to_existing`: Renaming a variable to an
+#'   existing name is an error.
+#'
 #' @seealso [vars_pull()]
 #' @export
 #' @keywords internal
@@ -274,12 +282,18 @@ inds_combine <- function(vars, inds) {
   }
 
   if (vctrs::vec_duplicate_any(renamers)) {
-    abort("Can't rename different columns to the same column name.")
+    abort(
+      "Can't rename different columns to the same column name.",
+      "tidyselect_error_rename_to_same"
+    )
   }
 
   unnamed_vars <- vars[incl[unnamed]]
   if (any(vctrs::vec_in(renamers, unnamed_vars))) {
-    abort("Can't rename column to an existing column name.")
+    abort(
+      "Can't rename column to an existing column name.",
+      "tidyselect_error_rename_to_existing"
+    )
   }
 
   names(incl)[unnamed] <- unnamed_vars

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -350,7 +350,7 @@ inds_check <- function(x, vars, incl, dups, unrenamed, unrenamed_vars) {
       glue::glue("* Columns {cols} are being renamed to `{dup}`.")
     })
     msg <- paste_line(
-      "Must use different names when renaming columns.",
+      "Must use unique names when renaming columns.",
       !!!probs
     )
 
@@ -365,7 +365,7 @@ inds_check <- function(x, vars, incl, dups, unrenamed, unrenamed_vars) {
       glue::glue("* Column `{col}` is being renamed to existing column `{dup}`.")
     })
     msg <- paste_line(
-      "Must use new name when renaming columns.",
+      "Must use unique name when renaming columns.",
       !!!probs
     )
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -162,8 +162,11 @@ vars_select <- function(.vars, ...,
 
   incl <- inds_combine(.vars, ind_list)
 
+  # Returned names must be unique
+  nms <- vctrs::vec_as_names(names(incl), repair = "unique")
+  sel <- set_names(.vars[incl], nms)
+
   # Include/.exclude specified variables
-  sel <- set_names(.vars[incl], names(incl))
   sel <- c(setdiff2(.include, sel), sel)
   sel <- setdiff2(sel, .exclude)
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -350,7 +350,7 @@ inds_check <- function(x, vars, incl, dups, unrenamed, unrenamed_vars) {
       glue::glue("* Columns {cols} are being renamed to `{dup}`.")
     })
     msg <- paste_line(
-      "Can't rename different columns to the same column name.",
+      "Must use different names when renaming columns.",
       !!!probs
     )
 
@@ -365,7 +365,7 @@ inds_check <- function(x, vars, incl, dups, unrenamed, unrenamed_vars) {
       glue::glue("* Column `{col}` is being renamed to existing column `{dup}`.")
     })
     msg <- paste_line(
-      "Can't rename column to an existing column name.",
+      "Must use new name when renaming columns.",
       !!!probs
     )
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -227,7 +227,7 @@ inds_combine <- function(vars, inds) {
   walk(inds, ind_check)
   first_negative <- length(inds) && length(inds[[1]]) && inds[[1]][[1]] < 0
 
-  inds <- vctrs::vec_c(!!!inds, .ptype = integer(), .name_spec = "{outer}{inner}")
+  inds <- vctrs::vec_c(!!!inds, .ptype = integer(), .name_spec = inds_name_spec)
   inds <- inds[inds != 0]
 
   if (first_negative) {
@@ -256,6 +256,14 @@ inds_combine <- function(vars, inds) {
   names(incl)[unnamed] <- vars[incl[unnamed]]
 
   incl
+}
+
+# The caller should deal with duplicates if `outer` is length > 1
+inds_name_spec <- function(outer, inner) {
+  if (!is_integer(inner)) {
+    abort("Internal error: Unexpected inner names in `inds_combine()`.")
+  }
+  outer
 }
 
 inds_unique <- function(x, vars) {

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -163,8 +163,7 @@ vars_select <- function(.vars, ...,
   incl <- inds_combine(.vars, ind_list)
 
   # Returned names must be unique
-  nms <- vctrs::vec_as_names(names(incl), repair = "unique")
-  sel <- set_names(.vars[incl], nms)
+  sel <- set_names(.vars[incl], names(incl))
 
   # Include/.exclude specified variables
   sel <- c(setdiff2(.include, sel), sel)

--- a/man/vars_select.Rd
+++ b/man/vars_select.Rd
@@ -65,6 +65,14 @@ in \code{...} causes the variables to be renamed. For technical
 reasons there can only be one target name. If the same variable
 is renamed to different names, tidyselect issues this warning.
 }
+
+\code{vars_select()} signals the following conditions.
+\itemize{
+\item \code{tidyselect_error_rename_to_same}: Renaming multiple variables to
+the same name is an error.
+\item \code{tidyselect_error_rename_to_existing}: Renaming a variable to an
+existing name is an error.
+}
 }
 
 \examples{

--- a/tests/testthat/helpers-tidyselect.R
+++ b/tests/testthat/helpers-tidyselect.R
@@ -1,6 +1,0 @@
-
-try2 <- function(what, expr, ...) {
-  cat("> #", what, "\n")
-  cat(">", deparse(substitute(expr)), "\n")
-  cat("Error:", catch_cnd(expr, classes = "error")$message, "\n\n")
-}

--- a/tests/testthat/helpers-tidyselect.R
+++ b/tests/testthat/helpers-tidyselect.R
@@ -1,0 +1,6 @@
+
+try2 <- function(what, expr, ...) {
+  cat("> #", what, "\n")
+  cat(">", deparse(substitute(expr)), "\n")
+  cat("Error:", catch_cnd(expr, classes = "error")$message, "\n\n")
+}

--- a/tests/testthat/outputs/vars-select-renaming-to-same.txt
+++ b/tests/testthat/outputs/vars-select-renaming-to-same.txt
@@ -1,0 +1,12 @@
+> # Renaming to same: 
+> vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e) 
+Error: Can't rename different columns to the same column name.
+* Columns `a` and `c` are being renamed to `foo`.
+* Columns `b` and `e` are being renamed to `bar`. 
+
+> # Renaming to existing: 
+> vars_select(letters, a = b, ok = c, d = e, everything()) 
+Error: Can't rename column to an existing column name.
+* Column `b` is being renamed to existing column `a`.
+* Column `e` is being renamed to existing column `d`. 
+

--- a/tests/testthat/outputs/vars-select-renaming-to-same.txt
+++ b/tests/testthat/outputs/vars-select-renaming-to-same.txt
@@ -1,12 +1,12 @@
 > # Renaming to same: 
 > vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e) 
-Error: Can't rename different columns to the same column name.
+Error: Must use different names when renaming columns.
 * Columns `a` and `c` are being renamed to `foo`.
 * Columns `b` and `e` are being renamed to `bar`. 
 
 > # Renaming to existing: 
 > vars_select(letters, a = b, ok = c, d = e, everything()) 
-Error: Can't rename column to an existing column name.
+Error: Must use new name when renaming columns.
 * Column `b` is being renamed to existing column `a`.
 * Column `e` is being renamed to existing column `d`. 
 

--- a/tests/testthat/outputs/vars-select-renaming-to-same.txt
+++ b/tests/testthat/outputs/vars-select-renaming-to-same.txt
@@ -1,12 +1,12 @@
 > # Renaming to same: 
 > vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e) 
-Error: Must use different names when renaming columns.
+Error: Must use unique names when renaming columns.
 * Columns `a` and `c` are being renamed to `foo`.
 * Columns `b` and `e` are being renamed to `bar`. 
 
 > # Renaming to existing: 
 > vars_select(letters, a = b, ok = c, d = e, everything()) 
-Error: Must use new name when renaming columns.
+Error: Must use unique name when renaming columns.
 * Column `b` is being renamed to existing column `a`.
 * Column `e` is being renamed to existing column `d`. 
 

--- a/tests/testthat/outputs/vars-select-renaming-to-same.txt
+++ b/tests/testthat/outputs/vars-select-renaming-to-same.txt
@@ -1,12 +1,10 @@
-> # Renaming to same: 
-> vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e) 
+> # Renaming to same:
+> vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e)
 Error: Must use unique names when renaming columns.
 * Columns `a` and `c` are being renamed to `foo`.
-* Columns `b` and `e` are being renamed to `bar`. 
-
-> # Renaming to existing: 
-> vars_select(letters, a = b, ok = c, d = e, everything()) 
+* Columns `b` and `e` are being renamed to `bar`.
+> # Renaming to existing:
+> vars_select(letters, a = b, ok = c, d = e, everything())
 Error: Must use unique name when renaming columns.
 * Column `b` is being renamed to existing column `a`.
-* Column `e` is being renamed to existing column `d`. 
-
+* Column `e` is being renamed to existing column `d`.

--- a/tests/testthat/test-inds-combine.R
+++ b/tests/testthat/test-inds-combine.R
@@ -51,8 +51,11 @@ test_that("if multiple names, last kept", {
   expect_identical(wrn$var, c(d = 1L, e = 1L))
 })
 
-test_that("if one name for multiple vars, let caller disambiguate", {
-  expect_equal(inds_combine(letters[1:3], list(x = 1:3)), c(x = 1, x = 2, x = 3))
+test_that("fails if one name for multiple vars", {
+  expect_error(
+    inds_combine(letters[1:3], list(x = 1:3)),
+    "to the same column name"
+  )
 })
 
 test_that("select(0) corner case #82", {

--- a/tests/testthat/test-inds-combine.R
+++ b/tests/testthat/test-inds-combine.R
@@ -51,10 +51,10 @@ test_that("if multiple names, last kept", {
   expect_identical(wrn$var, c(d = 1L, e = 1L))
 })
 
-test_that("fails if one name for multiple vars", {
-  expect_error(
+test_that("combine names if one name for multiple vars", {
+  expect_identical(
     inds_combine(letters[1:3], list(x = 1:3)),
-    "to the same column name"
+    c(x1 = 1L, x2 = 2L, x3 = 3L)
   )
 })
 

--- a/tests/testthat/test-inds-combine.R
+++ b/tests/testthat/test-inds-combine.R
@@ -51,8 +51,8 @@ test_that("if multiple names, last kept", {
   expect_identical(wrn$var, c(d = 1L, e = 1L))
 })
 
-test_that("if one name for multiple vars, use integer index", {
-  expect_equal(inds_combine(letters[1:3], list(x = 1:3)), c(x1 = 1, x2 = 2, x3 = 3))
+test_that("if one name for multiple vars, let caller disambiguate", {
+  expect_equal(inds_combine(letters[1:3], list(x = 1:3)), c(x = 1, x = 2, x = 3))
 })
 
 test_that("select(0) corner case #82", {

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -197,3 +197,17 @@ test_that("vars_select() fails when renaming to same name", {
   expect_error(vars_select(letters[1:3], a = b, a = c), class = "tidyselect_error_rename_to_same")
   expect_error(vars_select(letters[1:2], A = a, A = b), class = "tidyselect_error_rename_to_same")
 })
+
+test_that("vars_select() fails informatively", {
+  expect_known_output(file = test_path("outputs", "vars-select-renaming-to-same.txt"), {
+    try2(
+      "Renaming to same:",
+      vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e)
+    )
+
+    try2(
+      "Renaming to existing:",
+      vars_select(letters, a = b, ok = c, d = e, everything())
+    )
+  })
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -178,15 +178,19 @@ test_that("vars_select() can drop duplicate names by position (#94)", {
   expect_identical(vars_select(c("a", "b", "a"), -1), c(b = "b", a = "a"))
 })
 
-test_that("vars_select() can rename redundantly named vectors", {
+test_that("vars_select() can rename variables", {
   expect_identical(vars_select(letters[1:2], a = b), c(a = "b"))
   expect_identical(vars_select(letters[1:2], a = b, b = a), c(a = "b", b = "a"))
   expect_identical(vars_select(letters[1:2], a = b, a = b), c(a = "b"))
+})
 
+test_that("vars_select() can rename existing duplicates", {
+  expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b = "a", b = "a", a = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b = "a", b = "a"))
+})
+
+test_that("vars_select() fails when renaming to existing names", {
   expect_error(vars_select(letters[1:2], a, a = b), "rename column to an existing column name")
   expect_error(vars_select(letters[1:3], a = b, a = c), "rename different columns to the same column name")
   expect_error(vars_select(letters[1:2], A = a, A = b), "to the same")
-
-  expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b1 = "a", b2 = "a", a = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b1 = "a", b2 = "a"))
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -177,3 +177,8 @@ test_that("vars_select() can drop duplicate names by position (#94)", {
   expect_identical(vars_select(c("a", "b", "a"), -3), c(a = "a", b = "b"))
   expect_identical(vars_select(c("a", "b", "a"), -1), c(b = "b", a = "a"))
 })
+
+test_that("vars_select() can rename redundantly named vectors", {
+  expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b...1 = "a", b...2 = "a", a = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b...2 = "a", b...3 = "a"))
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -158,18 +158,18 @@ test_that("can rename and select at the same time", {
 
 test_that("vars_select() supports redundantly named vectors", {
   expect_identical(vars_select(c("a", "b", "a"), b), c(b = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), a), c(a...1 = "a", a...2 = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), a, b), c(a...1 = "a", a...2 = "a", b = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), b, a), c(b = "b", a...2 = "a", a...3 = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), c(b, a)), c(b = "b", a...2 = "a", a...3 = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), !!c(2, 1, 3)), c(b = "b", a...2 = "a", a...3 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), a), c(a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), a, b), c(a = "a", a = "a", b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), b, a), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), c(b, a)), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), !!c(2, 1, 3)), c(b = "b", a = "a", a = "a"))
 })
 
 test_that("select helpers support redundantly named vectors", {
-  expect_identical(vars_select(c("a", "b", "a"), everything()), c(a...1 = "a", b = "b", a...3 = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a...1 = "a", a...2 = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a...2 = "a", a...3 = "a"))
-  expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1...2 = "a1", a1...3 = "a1", a2 = "a2"))
+  expect_identical(vars_select(c("a", "b", "a"), everything()), c(a = "a", b = "b", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1 = "a1", a1 = "a1", a2 = "a2"))
 })
 
 test_that("vars_select() can drop duplicate names by position (#94)", {
@@ -179,6 +179,15 @@ test_that("vars_select() can drop duplicate names by position (#94)", {
 })
 
 test_that("vars_select() can rename redundantly named vectors", {
+  skip("Will fix after #115 has been merged")
+
+  # Should be an error:
+  vars_select(c("a", "b"), a, a = b)
+
+  # Should work:
+  vars_select(c("a", "b"), b = a, a = b)
+
+  # Do we tolerate this?
   expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b...1 = "a", b...2 = "a", a = "b"))
   expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b...2 = "a", b...3 = "a"))
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -155,3 +155,20 @@ test_that("vars_select() supports S3 vectors (#109)", {
 test_that("can rename and select at the same time", {
   expect_identical(vars_select(letters, c(1, a = 1, 1)), c(a = "a"))
 })
+
+test_that("vars_select() supports redundantly named vectors", {
+  expect_identical(vars_select(c("a", "b", "a"), b), c(b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), a), c(a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), a, b), c(a = "a", a = "a", b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), b, a), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), c(b, a)), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), !!c(2, 1, 3)), c(b = "b", a = "a", a = "a"))
+})
+
+test_that("select helpers support redundantly named vectors", {
+  expect_identical(vars_select(c("a", "b", "a"), everything()), c(a = "a", b = "b", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a = "a", a = "a"))
+
+  skip("FIXME")
+  expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a = "a", a = "a"))
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -9,11 +9,11 @@ test_that("last rename wins", {
   vars <- c("a", "b")
   expect_equal(
     expect_warning(
-      vars_select(vars, b = a, c = a),
-      "being renamed to \`b\` and \`c\`",
+      vars_select(vars, c = a, d = a),
+      "being renamed to \`c\` and \`d\`",
       fixed = TRUE
     ),
-    c("c" = "a")
+    c("d" = "a")
   )
 })
 
@@ -138,8 +138,8 @@ test_that("missing values are detected in vars_select() (#72)", {
 
 test_that("can use helper within c() (#91)", {
   expect_identical(
-    vars_select(letters, c(b = z, everything())),
-    vars_select(letters, b = z, everything())
+    vars_select(letters, c(B = z, everything())),
+    vars_select(letters, B = z, everything())
   )
 })
 
@@ -179,15 +179,14 @@ test_that("vars_select() can drop duplicate names by position (#94)", {
 })
 
 test_that("vars_select() can rename redundantly named vectors", {
-  skip("Will fix after #115 has been merged")
+  expect_identical(vars_select(letters[1:2], a = b), c(a = "b"))
+  expect_identical(vars_select(letters[1:2], a = b, b = a), c(a = "b", b = "a"))
+  expect_identical(vars_select(letters[1:2], a = b, a = b), c(a = "b"))
 
-  # Should be an error:
-  vars_select(c("a", "b"), a, a = b)
+  expect_error(vars_select(letters[1:2], a, a = b), "rename column to an existing column name")
+  expect_error(vars_select(letters[1:3], a = b, a = c), "rename different columns to the same column name")
+  expect_error(vars_select(letters[1:2], A = a, A = b), "to the same")
 
-  # Should work:
-  vars_select(c("a", "b"), b = a, a = b)
-
-  # Do we tolerate this?
-  expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b...1 = "a", b...2 = "a", a = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b...2 = "a", b...3 = "a"))
+  expect_error(vars_select(c("a", "b", "a"), b = a, a = b), "to the same")
+  expect_error(vars_select(c("a", "b", "a"), a = b, b = a), "to the same")
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -158,16 +158,16 @@ test_that("can rename and select at the same time", {
 
 test_that("vars_select() supports redundantly named vectors", {
   expect_identical(vars_select(c("a", "b", "a"), b), c(b = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), a), c(a = "a", a = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), a, b), c(a = "a", a = "a", b = "b"))
-  expect_identical(vars_select(c("a", "b", "a"), b, a), c(b = "b", a = "a", a = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), c(b, a)), c(b = "b", a = "a", a = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), !!c(2, 1, 3)), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), a), c(a...1 = "a", a...2 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), a, b), c(a...1 = "a", a...2 = "a", b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), b, a), c(b = "b", a...2 = "a", a...3 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), c(b, a)), c(b = "b", a...2 = "a", a...3 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), !!c(2, 1, 3)), c(b = "b", a...2 = "a", a...3 = "a"))
 })
 
 test_that("select helpers support redundantly named vectors", {
-  expect_identical(vars_select(c("a", "b", "a"), everything()), c(a = "a", b = "b", a = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a = "a", a = "a"))
-  expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a = "a", a = "a"))
-  expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1 = "a1", a1 = "a1", a2 = "a2"))
+  expect_identical(vars_select(c("a", "b", "a"), everything()), c(a...1 = "a", b = "b", a...3 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a...1 = "a", a...2 = "a"))
+  expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a...2 = "a", a...3 = "a"))
+  expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1...2 = "a1", a1...3 = "a1", a2 = "a2"))
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -199,15 +199,11 @@ test_that("vars_select() fails when renaming to same name", {
 })
 
 test_that("vars_select() fails informatively", {
-  expect_known_output(file = test_path("outputs", "vars-select-renaming-to-same.txt"), {
-    try2(
-      "Renaming to same:",
-      vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e)
-    )
+  verify_output(test_path("outputs", "vars-select-renaming-to-same.txt"), {
+    "Renaming to same:"
+    vars_select(letters, foo = a, bar = b, foo = c, ok = d, bar = e)
 
-    try2(
-      "Renaming to existing:",
-      vars_select(letters, a = b, ok = c, d = e, everything())
-    )
+    "Renaming to existing:"
+    vars_select(letters, a = b, ok = c, d = e, everything())
   })
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -189,8 +189,11 @@ test_that("vars_select() can rename existing duplicates", {
   expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b = "a", b = "a"))
 })
 
-test_that("vars_select() fails when renaming to existing names", {
-  expect_error(vars_select(letters[1:2], a, a = b), "rename column to an existing column name")
-  expect_error(vars_select(letters[1:3], a = b, a = c), "rename different columns to the same column name")
-  expect_error(vars_select(letters[1:2], A = a, A = b), "to the same")
+test_that("vars_select() fails when renaming to existing name", {
+  expect_error(vars_select(letters[1:2], a, a = b), class = "tidyselect_error_rename_to_existing")
+})
+
+test_that("vars_select() fails when renaming to same name", {
+  expect_error(vars_select(letters[1:3], a = b, a = c), class = "tidyselect_error_rename_to_same")
+  expect_error(vars_select(letters[1:2], A = a, A = b), class = "tidyselect_error_rename_to_same")
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -187,6 +187,6 @@ test_that("vars_select() can rename redundantly named vectors", {
   expect_error(vars_select(letters[1:3], a = b, a = c), "rename different columns to the same column name")
   expect_error(vars_select(letters[1:2], A = a, A = b), "to the same")
 
-  expect_error(vars_select(c("a", "b", "a"), b = a, a = b), "to the same")
-  expect_error(vars_select(c("a", "b", "a"), a = b, b = a), "to the same")
+  expect_identical(vars_select(c("a", "b", "a"), b = a, a = b), c(b1 = "a", b2 = "a", a = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), a = b, b = a), c(a = "b", b1 = "a", b2 = "a"))
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -171,3 +171,9 @@ test_that("select helpers support redundantly named vectors", {
   expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a...2 = "a", a...3 = "a"))
   expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1...2 = "a1", a1...3 = "a1", a2 = "a2"))
 })
+
+test_that("vars_select() can drop duplicate names by position (#94)", {
+  expect_identical(vars_select(c("a", "b", "a"), 2), c(b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), -3), c(a = "a", b = "b"))
+  expect_identical(vars_select(c("a", "b", "a"), -1), c(b = "b", a = "a"))
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -168,7 +168,6 @@ test_that("vars_select() supports redundantly named vectors", {
 test_that("select helpers support redundantly named vectors", {
   expect_identical(vars_select(c("a", "b", "a"), everything()), c(a = "a", b = "b", a = "a"))
   expect_identical(vars_select(c("a", "b", "a"), starts_with("a")), c(a = "a", a = "a"))
-
-  skip("FIXME")
   expect_identical(vars_select(c("a", "b", "a"), one_of(c("b", "a"))), c(b = "b", a = "a", a = "a"))
+  expect_identical(vars_select(c("a1", "b", "a1", "a2"), b, num_range("a", 1:2)), c(b = "b", a1 = "a1", a1 = "a1", a2 = "a2"))
 })


### PR DESCRIPTION
Closes #94.

`vars_select()` now ignores duplicate variables that were not selected:

```r
vars <- c("a", "b", "a")

vars_select(vars, -3)
#>   a   b
#> "a" "b"

vars_select(vars, b)
#>   b
#> "b"
```

If selected, the duplicate variables are renamed to their repaired form:

```r
vars_select(vars, a)
#> New names:
#> * a -> a...1
#> * a -> a...2
#> a...1 a...2
#>   "a"   "a"

vars_select(vars, one_of(c("b", "a")))
#> New names:
#> * a -> a...2
#> * a -> a...3
#>     b a...2 a...3
#>   "b"   "a"   "a"
```

This repairing is not very useful yet because `vars_select()` returns a character vector. Ideally it'd return an integer vector of positions so the duplicate variables can be disambiguated. We'll tackle this as part of the UI update in #89.

I don't expect many breakages as duplicate variable names are a rare corner case. As far as `dplyr::select()` is concerned, this will continue to be an error because it checks for unique values:

```r
dups <- new_tibble(list(a = 1, b = 2, a = 3), nrow = 1)

dplyr::select(dups, b, a)
#> New names:
#> * a -> a...2
#> * a -> a...3
#> Error: Column `a` must have a unique name
```