### PR TITLE
Recommend using `all_of()` for looking up variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,23 @@
 
 # tidyselect (development)
 
+* Selection helpers like `all_of()` and `starts_with()` are now
+  available in all selection contexts, even when they haven't been
+  attached to the search path. The most visible consequence of this
+  change is that it is now easier to use selection functions without
+  attaching the host package:
+
+  ```r
+  # Before
+  dplyr::select(mtcars, dplyr::starts_with("c"))
+
+  # After
+  dplyr::select(mtcars, starts_with("c"))
+  ```
+
+  It is still recommended to export the helpers from your package so
+  that users can easily look up the documentation with `?`.
+
 * Selecting non-column variables with bare names now triggers an
   informative message suggesting to use `all_of()` instead. Referring
   to contextual objects with a bare name is brittle because it might

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # tidyselect (development)
 
+* Selecting non-column variables with bare names now triggers an
+  informative message suggesting to use `all_of()` instead. Referring
+  to contextual objects with a bare name is brittle because it might
+  be masked by a data frame column. Using `all_of()` is safe (#76).
+
 * Using arithmetic operators in selection context now fails more
   informatively (#84).
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -628,6 +628,11 @@ eval_sym <- function(name, data_mask, context_mask, colon = FALSE) {
   )
 
   if (!is_missing(value)) {
+    inform(glue_c(
+      "Note: Selecting non-column variables is brittle.",
+      i = "If the data contains `{name}` it will be selected instead.",
+      i = "Use `all_of({name})` to silence this message."
+    ))
     return(value)
   }
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -407,7 +407,7 @@ vars_select_eval <- function(vars, quos) {
     # Add `.data` pronoun in the context mask even though it doesn't
     # contain data. This way the pronoun can be used in any parts of the
     # expression.
-    context_mask <- new_data_mask(env())
+    context_mask <- new_data_mask(env(!!!vars_select_helpers))
     context_mask$.data <- data_mask$.data
   }
 

--- a/tests/testthat/outputs/vars-select-context-lookup.txt
+++ b/tests/testthat/outputs/vars-select-context-lookup.txt
@@ -1,0 +1,8 @@
+> vars_select(letters, vars)
+Message: Note: Selecting non-column variables is brittle.
+i If the data contains `vars` it will be selected instead.
+i Use `all_of(vars)` to silence this message.
+
+  a   b 
+"a" "b" 
+

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -124,3 +124,15 @@ test_that("can't use arithmetic operators in data context", {
 test_that("can use arithmetic operators in non-data context", {
   expect_identical(vars_select(letters, identity(2 * 2 + 2 ^ 2 / 2)), c(f = "f"))
 })
+
+test_that("symbol lookup outside data informs caller about better practice", {
+  vars <- c("a", "b")
+  expect_message(
+    vars_select(letters, vars),
+    "Use `all_of(vars)` to silence",
+    fixed = TRUE
+  )
+  verify_output(test_path("outputs", "vars-select-context-lookup.txt"), {
+    vars_select(letters, vars)
+  })
+})

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -136,3 +136,10 @@ test_that("symbol lookup outside data informs caller about better practice", {
     vars_select(letters, vars)
   })
 })
+
+test_that("selection helpers are in the context mask", {
+  out <- local(envir = baseenv(), {
+    tidyselect::vars_select(letters, all_of("a"))
+  })
+  expect_identical(out, c(a = "a"))
+})


### PR DESCRIPTION
First step towards #76. For now this is a simple message:

```r
vars <- letters[1:4]
vars_select(letters, vars)
#> Note: Selecting non-column variables is brittle.
#> ℹ If the data contains `vars` it will be selected instead.
#> ℹ Use `all_of(vars)` to silence this message.
#>   a   b   c   d
#> "a" "b" "c" "d"
```

We can move on to formally deprecating this kind of lookup in the next version.

I would like to refer to `all_of()` in the message, but there will be a transition period where dplyr hasn't exported the new selectors. To work around this, the second commit binds the selection helpers inside the context mask. This is what several client packages are already doing. This makes it easier to use dplyr functions without the package attached:

```r
# Before
dplyr::select(mtcars, dplyr::starts_with("c"))

# After
dplyr::select(mtcars, starts_with("c"))
```

It is still recommended to export the helpers so their help topics are easily accessible.