### PR TITLE
Add non-strict handling to selection interpreter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # tidyselect (development)
 
+* The `.strict` argument of `vars_select()` now works more robustly
+  and consistently.
+
 * `starts_with()`, `ends_with()`, `contains()`, and `matches()` now
   accept vector inputs (#50). For instance these are now equivalent
   ways of selecting all variables that start with either `"a"` or `"b"`:

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -166,12 +166,7 @@ num_range <- function(prefix, range, width = NULL, vars = peek_vars()) {
 #' @export
 all_of <- function(x, ..., vars = peek_vars()) {
   ellipsis::check_dots_empty()
-
-  n <- length(vars)
-  subclass_index_errors(
-    vctrs::vec_as_index(x, n, names = vars, allow_types = "name"),
-    allow_positions = FALSE
-  )
+  x
 }
 
 #' @rdname select_helpers

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -161,11 +161,10 @@ num_range <- function(prefix, range, width = NULL, vars = peek_vars()) {
 }
 
 #' @rdname select_helpers
-#' @param x A character vector.
+#' @param x An index vector of names or positions.
 #' @inheritParams ellipsis::dots_empty
 #' @export
-all_of <- function(x, ..., vars = peek_vars()) {
-  ellipsis::check_dots_empty()
+all_of <- function(x) {
   x
 }
 

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -173,16 +173,7 @@ all_of <- function(x, ..., vars = peek_vars()) {
 #' @export
 any_of <- function(x, ..., vars = peek_vars()) {
   ellipsis::check_dots_empty()
-
-  x <- subclass_index_errors(
-    vctrs::vec_coerce_index(x, allow_types = "name"),
-    allow_positions = FALSE
-  )
-
-  # Ensure missing values slip through (they cause an error later on)
-  vars <- c(vars, na_chr)
-
-  set_intersect(vars, x)
+  as_indices_impl(x, vars = vars, strict = FALSE)
 }
 
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,9 +126,7 @@ set_diff <- function(x, y) {
   vctrs::vec_slice(x, !vctrs::vec_in(x, y))
 }
 set_intersect <- function(x, y) {
-  loc_in_y <- match(x, y)
-  loc_in_y <- vctrs::vec_slice(loc_in_y, !is.na(loc_in_y))
-  vctrs::vec_slice(y, loc_in_y)
+  vctrs::vec_slice(x, match(y, x, 0))
 }
 
 vec_is_subtype <- function(x, super, ..., x_arg = "x", super_arg = "super") {

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -94,7 +94,7 @@ as_indices_impl <- function(x, vars, strict) {
   if (!strict) {
     # Remove out-of-bounds elements if non-strict
     x <- switch(typeof(x),
-      character = intersect(x, vars),
+      character = set_intersect(x, c(vars, na_chr)),
       double = ,
       integer = x[x <= length(vars)]
     )

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -139,11 +139,7 @@ vars_select <- function(.vars, ...,
     return(empty_sel(.vars, .include, .exclude))
   }
 
-  if (!.strict) {
-    quos <- ignore_unknown_symbols(.vars, quos)
-  }
-
-  ind_list <- subclass_index_errors(vars_select_eval(.vars, quos))
+  ind_list <- subclass_index_errors(vars_select_eval(.vars, quos, .strict))
   check_missing(ind_list, quos)
 
   if (is_empty(ind_list)) {
@@ -187,44 +183,4 @@ vars_select <- function(.vars, ...,
 empty_sel <- function(vars, include, exclude) {
   vars <- setdiff(include, exclude)
   set_names(vars, vars)
-}
-
-ignore_unknown_symbols <- function(vars, quos) {
-  quos <- discard(quos, is_ignored, vars)
-  quos <- map_if(quos, quo_is_concat_call, call_ignore_unknown_symbols, vars)
-  quos
-}
-call_ignore_unknown_symbols <- function(quo, vars) {
-  expr <- quo_get_expr(quo)
-
-  args <- call_args(expr)
-  args <- discard(args, is_unknown_symbol, vars)
-  expr <- call2(node_car(expr), !!! args)
-
-  quo_set_expr(quo, expr)
-}
-
-is_ignored <- function(quo, vars) {
-  is_unknown_symbol(quo, vars) || is_ignored_minus_call(quo, vars)
-}
-is_ignored_minus_call <- function(quo, vars) {
-  expr <- maybe_unwrap_quosure(quo)
-
-  if (!is_call(expr, quote(`-`), 1L)) {
-    return(FALSE)
-  }
-
-  is_unknown_symbol(node_cadr(expr), vars)
-}
-is_unknown_symbol <- function(quo, vars) {
-  expr <- maybe_unwrap_quosure(quo)
-
-  if (!is_symbol(expr) && !is_string(expr)) {
-    return(FALSE)
-  }
-
-  !as_string(expr) %in% vars
-}
-quo_is_concat_call <- function(quo) {
-  quo_is_call(quo, quote(`c`))
 }

--- a/man/select_helpers.Rd
+++ b/man/select_helpers.Rd
@@ -23,7 +23,7 @@ matches(match, ignore.case = TRUE, perl = FALSE, vars = peek_vars())
 
 num_range(prefix, range, width = NULL, vars = peek_vars())
 
-all_of(x, ..., vars = peek_vars())
+all_of(x)
 
 any_of(x, ..., vars = peek_vars())
 
@@ -51,7 +51,7 @@ automatically set to the names of the table.}
 \item{width}{Optionally, the "width" of the numeric range. For example,
 a range of 2 gives "01", a range of three "001", etc.}
 
-\item{x}{A character vector.}
+\item{x}{An index vector of names or positions.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -341,3 +341,10 @@ test_that("matchers accept length > 1 vectors (#50)", {
     vars_select(names(iris), matches("epal") | contains("eta")),
   )
 })
+
+test_that("`all_of()` doesn't fail if `.strict` is FALSE", {
+  expect_identical(
+    vars_select(letters, all_of(c("a", "bar", "c")), .strict = FALSE),
+    c(a = "a", c = "c")
+  )
+})

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -315,8 +315,6 @@ test_that("any_of() is lax", {
 })
 
 test_that("all_of() and any_of() check their inputs", {
-  expect_error(vars_select(letters, all_of(1L)), class = "tidyselect_error_index_bad_type")
-  expect_error(vars_select(letters, any_of(1L)), class = "tidyselect_error_index_bad_type")
   expect_error(vars_select(letters, all_of(NA)), "missing")
   expect_error(vars_select(letters, any_of(NA)), "missing")
   expect_error(vars_select(letters, all_of(na_chr)), "missing")

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -319,6 +319,8 @@ test_that("all_of() and any_of() check their inputs", {
   expect_error(vars_select(letters, any_of(NA)), "missing")
   expect_error(vars_select(letters, all_of(na_chr)), "missing")
   expect_error(vars_select(letters, any_of(na_chr)), "missing")
+  expect_error(vars_select(letters, all_of(TRUE)), class = "tidyselect_error_index_bad_type")
+  expect_error(vars_select(letters, any_of(TRUE)), class = "tidyselect_error_index_bad_type")
 })
 
 test_that("matchers accept length > 1 vectors (#50)", {

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -143,3 +143,22 @@ test_that("selection helpers are in the context mask", {
   })
   expect_identical(out, c(a = "a"))
 })
+
+test_that("non-strict evaluation allows unknown variables", {
+  expect_identical(
+    vars_select(letters, identity("foo"), .strict = FALSE),
+    vars_select(letters, int())
+  )
+  expect_identical(
+    vars_select(letters, identity(100), .strict = FALSE),
+    vars_select(letters, int())
+  )
+  expect_identical(
+    vars_select(letters, -identity("foo"), .strict = FALSE),
+    vars_select(letters, -int())
+  )
+  expect_identical(
+    vars_select(letters, -identity(100), .strict = FALSE),
+    vars_select(letters, -int())
+  )
+})


### PR DESCRIPTION
* The `.strict` argument is now handled from the selection interpreter, fixing many bugs.

* It is now easier for selection helpers to depend on `.strict`: just return out-of-bounds names or indices, and the interpreter will drop them if `.strict` is FALSE, or throw an OOB error otherwise.

* `all_of()` becomes the identity function. `any_of()` uses the same routine as the interpreter to force non-strict selection.