### PR TITLE
Implement `select_pos()`

### DIFF
--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -165,6 +165,12 @@ num_range <- function(prefix, range, width = NULL, vars = peek_vars()) {
 #' @inheritParams ellipsis::dots_empty
 #' @export
 all_of <- function(x) {
+  if (is.function(x)) {
+    # Trigger bad type error
+    vctrs::vec_as_index(x, 0L)
+    abort("Internal error: `all_of()` should have failed sooner")
+  }
+
   x
 }
 

--- a/R/select.R
+++ b/R/select.R
@@ -22,12 +22,9 @@ select_pos <- function(.x,
 }
 
 # Example of implementation, mainly used for unit tests
-vec_select <- function(.x, ..., .strict = TRUE) {
-  if (is.data.frame(.x)) {
-    abort("`.x` can't be a data frame.")
-  }
+select <- function(.x, ..., .strict = TRUE) {
   idx <- select_pos(.x, ..., .strict = .strict)
-  set_names(vctrs::vec_slice(.x, idx), names(idx))
+  set_names(.x[idx], names(idx))
 }
 
 select_impl <- function(.x = NULL,

--- a/R/select.R
+++ b/R/select.R
@@ -4,6 +4,8 @@ select_pos <- function(.x,
                        .include = NULL,
                        .exclude = NULL,
                        .strict = TRUE) {
+  vctrs::vec_assert(.x)
+
   vars <- names(.x)
   if (is_null(vars)) {
     abort("Can't select within an unnamed vector.")

--- a/R/select.R
+++ b/R/select.R
@@ -44,10 +44,10 @@ select_impl <- function(.x = NULL,
   }
 
   if (length(.include)) {
-    dots <- list(expr(all_of(!!.include) | c(!!!dots)))
+    dots <- list(quo(all_of(.include) | c(!!!dots)))
   }
   if (length(.exclude)) {
-    dots <- list(expr(c(!!!dots, -!!.exclude)))
+    dots <- list(quo(c(!!!dots, -.exclude)))
   }
 
   inds <- subclass_index_errors(

--- a/R/select.R
+++ b/R/select.R
@@ -1,0 +1,53 @@
+
+select_pos <- function(.x, ..., .strict = TRUE) {
+  vars <- names(.x)
+  if (is_null(vars)) {
+    abort("Can't select within an unnamed vector.")
+  }
+
+  scoped_vars(vars)
+  select_impl(.x, ..., .strict = .strict)
+}
+
+# Example of implementation, mainly used for unit tests
+vec_select <- function(.x, ..., .strict = TRUE) {
+  if (is.data.frame(.x)) {
+    abort("`.x` can't be a data frame.")
+  }
+  idx <- select_pos(.x, ..., .strict = .strict)
+  set_names(vctrs::vec_slice(.x, idx), names(idx))
+}
+
+select_impl <- function(.x = NULL,
+                        ...,
+                        .strict = TRUE) {
+  dots <- enquos(...)
+  vars <- peek_vars()
+
+  ind_list <- subclass_index_errors(
+    vars_select_eval(vars, dots, .strict, data = .x)
+  )
+
+  # If the first selector is exclusive (negative), start with all
+  # columns. We need to check for symbolic `-` here because if the
+  # selection is empty, `inds_combine()` cannot detect a negative
+  # indice in first position.
+  if (is_negated(quo_get_expr(dots[[1]]))) {
+    ind_list <- c(list(seq_along(vars)), ind_list)
+  }
+
+  inds_combine(vars, ind_list)
+}
+
+is_negated <- function(x) {
+  repeat {
+    x <- quo_get_expr2(x, x)
+
+    if (!is_call(x, "c")) {
+      break
+    }
+    x <- node_cadr(x)
+  }
+
+  is_call(x, "-", n = 1)
+}

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -1,11 +1,8 @@
 
-vars_select_eval <- function(vars, quos, strict) {
+vars_select_eval <- function(vars, quos, strict, data = NULL) {
   is_symbolic <- map_lgl(quos, quo_is_symbolic)
 
   if (any(is_symbolic)) {
-    scoped_vars(vars)
-
-    # Peek validated variables
     vars <- peek_vars()
 
     vars_split <- vctrs::vec_split(seq_along(vars), vars)
@@ -27,8 +24,9 @@ vars_select_eval <- function(vars, quos, strict) {
     context_mask <- new_data_mask(env(!!!vars_select_helpers))
     context_mask$.data <- data_mask$.data
 
-    # Save metadata in masks
+    # Save metadata in mask
     data_mask$.__tidyselect__.$internal$vars <- vars
+    data_mask$.__tidyselect__.$internal$data <- data
     data_mask$.__tidyselect__.$internal$strict <- strict
   }
 
@@ -263,11 +261,11 @@ eval_sym <- function(name, data_mask, context_mask, colon = FALSE) {
   )
 
   if (!is_missing(value)) {
-    inform(glue_c(
-      "Note: Using an external vector in selections is brittle.",
-      i = "If the data contains `{name}` it will be selected instead.",
-      i = "Use `all_of({name})` instead of just `{name}` to silence this message."
-    ))
+      inform(glue_c(
+        "Note: Using an external vector in selections is brittle.",
+        i = "If the data contains `{name}` it will be selected instead.",
+        i = "Use `all_of({name})` instead of just `{name}` to silence this message."
+      ))
     return(value)
   }
 

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -261,11 +261,20 @@ eval_sym <- function(name, data_mask, context_mask, colon = FALSE) {
   )
 
   if (!is_missing(value)) {
+    if (is_function(value)) {
+      data <- data_mask$.__tidyselect__.$internal$data
+      if (is_null(data)) {
+        abort("This tidyselect interface doesn't support predicates yet.")
+      }
+      value <- which(map_lgl(data, value))
+    } else {
       inform(glue_c(
         "Note: Using an external vector in selections is brittle.",
         i = "If the data contains `{name}` it will be selected instead.",
         i = "Use `all_of({name})` instead of just `{name}` to silence this message."
       ))
+    }
+
     return(value)
   }
 

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -1,6 +1,6 @@
 
 vars_select_eval <- function(vars, quos, strict, data = NULL) {
-  is_symbolic <- map_lgl(quos, quo_is_symbolic)
+  is_symbolic <- map_lgl(quos, function(x) is_symbolic(quo_get_expr2(x, x)))
 
   if (any(is_symbolic)) {
     vars <- peek_vars()
@@ -39,7 +39,7 @@ vars_select_eval <- function(vars, quos, strict, data = NULL) {
       context_mask
     ),
     .else = ~ as_indices_sel_impl(
-      quo_get_expr(.),
+      quo_get_expr2(., .),
       vars = vars,
       strict = strict,
       data = data
@@ -65,7 +65,7 @@ walk_data_tree <- function(expr, data_mask, context_mask, colon = FALSE) {
   # later on.
   if (is_quosure(expr)) {
     scoped_bindings(.__current__. = quo_get_env(expr), .env = context_mask)
-    expr <- quo_get_expr(expr)
+    expr <- quo_get_expr2(expr, expr)
   }
 
   out <- switch(expr_kind(expr),
@@ -240,7 +240,7 @@ eval_c <- function(expr, data_mask, context_mask) {
 eval_c_arg <- function(expr, data_mask, context_mask) {
   if (is_quosure(expr)) {
     scoped_bindings(.__current__. = quo_get_env(expr), .env = context_mask)
-    expr <- quo_get_expr(expr)
+    expr <- quo_get_expr2(expr, expr)
   }
 
   if (is_symbol(expr, "...")) {

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -287,7 +287,7 @@ eval_sym <- function(name, data_mask, context_mask, colon = FALSE) {
       inform(glue_c(
         "Note: Using an external vector in selections is brittle.",
         i = "If the data contains `{name}` it will be selected instead.",
-        i = "Use `all_of({name})` instead of just `{name}` to silence this message."
+        i = "Use `all_of({name})` instead of `{name}` to silence this message."
       ))
     }
 

--- a/R/vars-select-eval.R
+++ b/R/vars-select-eval.R
@@ -254,7 +254,8 @@ eval_c_arg <- function(expr, data_mask, context_mask) {
 }
 
 eval_context <- function(expr, context_mask) {
-  expr <- as_quosure(expr, context_mask$.__current__.)
+  env <- context_mask$.__current__. %||% base_env()
+  expr <- as_quosure(expr, env)
   eval_tidy(expr, context_mask)
 }
 

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -151,14 +151,6 @@ vars_select <- function(.vars,
 
   sel <- set_names(.vars[idx], names(idx))
 
-  # Include/.exclude specified variables
-  if (length(.include)) {
-    sel <- c(setdiff(.include, sel), sel)
-  }
-  if (length(.exclude)) {
-    sel <- setdiff(sel, .exclude)
-  }
-
   # Ensure all output are named, with `.vars` as default
   if (is_empty(sel)) {
     signal("", "tidyselect_empty")

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -128,36 +128,28 @@
 #'   vars_select(names(mtcars), !! enquo(var1), !! enquo(var2))
 #' }
 #' wrapper(starts_with("d"), starts_with("c"))
-vars_select <- function(.vars, ...,
+vars_select <- function(.vars,
+                        ...,
                         .include = character(),
                         .exclude = character(),
                         .strict = TRUE) {
-  quos <- quos(...)
+  scoped_vars(.vars)
 
-  if (!length(quos)) {
+  dots <- enquos(...)
+  if (!length(dots)) {
     signal("", "tidyselect_empty_dots")
     return(empty_sel(.vars, .include, .exclude))
   }
 
-  ind_list <- subclass_index_errors(vars_select_eval(.vars, quos, .strict))
+  idx <- select_impl(
+    NULL,
+    !!!dots,
+    .include = .include,
+    .exclude = .exclude,
+    .strict = .strict
+  )
 
-  if (is_empty(ind_list)) {
-    signal("", "tidyselect_empty")
-    return(empty_sel(.vars, .include, .exclude))
-  }
-
-  # If the first selector is exclusive (negative), start with all
-  # columns. We need to check for symbolic `-` here because if the
-  # selection is empty, `inds_combine()` cannot detect a negative
-  # indice in first position.
-  if (is_negated(quos[[1]])) {
-    ind_list <- c(list(seq_along(.vars)), ind_list)
-  }
-
-  incl <- inds_combine(.vars, ind_list)
-
-  # Returned names must be unique
-  sel <- set_names(.vars[incl], names(incl))
+  sel <- set_names(.vars[idx], names(idx))
 
   # Include/.exclude specified variables
   if (length(.include)) {
@@ -167,10 +159,10 @@ vars_select <- function(.vars, ...,
     sel <- setdiff(sel, .exclude)
   }
 
-  # Ensure all output .vars named
+  # Ensure all output are named, with `.vars` as default
   if (is_empty(sel)) {
     signal("", "tidyselect_empty")
-    names(sel) <- sel
+    names(sel) <- chr()
   } else {
     unnamed <- names2(sel) == ""
     names(sel)[unnamed] <- sel[unnamed]
@@ -182,17 +174,4 @@ vars_select <- function(.vars, ...,
 empty_sel <- function(vars, include, exclude) {
   vars <- setdiff(include, exclude)
   set_names(vars, vars)
-}
-
-is_negated <- function(x) {
-  repeat {
-    x <- quo_get_expr2(x, x)
-
-    if (!is_call(x, "c")) {
-      break
-    }
-    x <- node_cadr(x)
-  }
-
-  is_call(x, "-", n = 1)
 }

--- a/tests/testthat/outputs/select-eval-boolean-errors.txt
+++ b/tests/testthat/outputs/select-eval-boolean-errors.txt
@@ -1,0 +1,14 @@
+> # Unknown names
+> select_pos(mtcars, foobar & contains("am"))
+Error: Must select existing columns.
+x Can't subset element with unknown name `foobar`.
+
+> select_pos(mtcars, contains("am") | foobar)
+Error: Must select existing columns.
+x Can't subset element with unknown name `foobar`.
+
+> # Empty intersection
+> select_pos(mtcars, cyl & am)
+Error: Can't take the intersection of two columns.
+i `cyl & am` is always an empty selection.
+

--- a/tests/testthat/outputs/vars-select-bool-symbols.txt
+++ b/tests/testthat/outputs/vars-select-bool-symbols.txt
@@ -1,6 +1,0 @@
-> vars_select(letters, starts_with("a") & z)
-Error in eval_tidy(expr, context_mask): object 'z' not found
-
-> vars_select(letters, starts_with("a") | z)
-Error in eval_tidy(expr, context_mask): object 'z' not found
-

--- a/tests/testthat/outputs/vars-select-bool-symbols.txt
+++ b/tests/testthat/outputs/vars-select-bool-symbols.txt
@@ -1,10 +1,6 @@
 > vars_select(letters, starts_with("a") & z)
-Error: Can't use boolean operators with bare variables.
-x `z` is a bare variable.
-i Do you need `all_of(z)`?
+Error in eval_tidy(expr, context_mask): object 'z' not found
 
 > vars_select(letters, starts_with("a") | z)
-Error: Can't use boolean operators with bare variables.
-x `z` is a bare variable.
-i Do you need `all_of(z)`?
+Error in eval_tidy(expr, context_mask): object 'z' not found
 

--- a/tests/testthat/outputs/vars-select-context-lookup.txt
+++ b/tests/testthat/outputs/vars-select-context-lookup.txt
@@ -1,7 +1,7 @@
 > vars_select(letters, vars)
 Message: Note: Using an external vector in selections is brittle.
 i If the data contains `vars` it will be selected instead.
-i Use `all_of(vars)` instead of just `vars` to silence this message.
+i Use `all_of(vars)` instead of `vars` to silence this message.
 
   a   b 
 "a" "b" 

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -352,3 +352,10 @@ test_that("`all_of()` doesn't fail if `.strict` is FALSE", {
     c(a = "a", c = "c")
   )
 })
+
+test_that("`all_of()` requires indices", {
+  expect_error(
+    select(iris, all_of(is.factor)),
+    class = "tidyselect_error_index_bad_type"
+  )
+})

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -104,6 +104,10 @@ test_that("position must resolve to numeric variables throws error", {
   )
   expect_error(
     vars_select(letters, !!function() NULL),
+    "doesn't support predicates yet"
+  )
+  expect_error(
+    vars_select(letters, !!env()),
     class = "tidyselect_error_index_bad_type"
   )
 })

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -1,0 +1,17 @@
+context("select")
+
+test_that("vec_select() is generic", {
+  expect_identical(
+    vec_select(set_names(letters), b:c),
+    c(b = "b", c = "c")
+  )
+  expect_identical(
+    vec_select(as.list(set_names(letters)), b:c),
+    list(b = "b", c = "c")
+  )
+})
+
+test_that("vec_select() supports existing duplicates", {
+  x <- list(a = 1, b = 2, a = 3)
+  expect_identical(vec_select(x, A = a), list(A = 1, A = 3))
+})

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -15,3 +15,13 @@ test_that("vec_select() supports existing duplicates", {
   x <- list(a = 1, b = 2, a = 3)
   expect_identical(vec_select(x, A = a), list(A = 1, A = 3))
 })
+
+test_that("can call `select_pos()` without arguments", {
+  expect_identical(select_pos(mtcars), set_names(int(), chr()))
+})
+
+test_that("can specify inclusion and exclusion", {
+  x <- list(a = 1, b = 2, c = 3)
+  expect_identical(select_pos(x, int(), .include = "b"), c(b = 2L))
+  expect_identical(select_pos(x, -int(), .exclude = c("a", "c")), c(b = 2L))
+})

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -1,19 +1,19 @@
 context("select")
 
-test_that("vec_select() is generic", {
+test_that("select() is generic", {
   expect_identical(
-    vec_select(set_names(letters), b:c),
+    select(set_names(letters), b:c),
     c(b = "b", c = "c")
   )
   expect_identical(
-    vec_select(as.list(set_names(letters)), b:c),
+    select(as.list(set_names(letters)), b:c),
     list(b = "b", c = "c")
   )
 })
 
-test_that("vec_select() supports existing duplicates", {
+test_that("select() supports existing duplicates", {
   x <- list(a = 1, b = 2, a = 3)
-  expect_identical(vec_select(x, A = a), list(A = 1, A = 3))
+  expect_identical(select(x, A = a), list(A = 1, A = 3))
 })
 
 test_that("can call `select_pos()` without arguments", {

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -25,3 +25,7 @@ test_that("can specify inclusion and exclusion", {
   expect_identical(select_pos(x, int(), .include = "b"), c(b = 2L))
   expect_identical(select_pos(x, -int(), .exclude = c("a", "c")), c(b = 2L))
 })
+
+test_that("select_pos() checks inputs", {
+  expect_error(select_pos(function() NULL), class = "vctrs_error_scalar_type")
+})

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -129,7 +129,7 @@ test_that("symbol lookup outside data informs caller about better practice", {
   vars <- c("a", "b")
   expect_message(
     vars_select(letters, vars),
-    "Use `all_of(vars)` instead of just `vars` to silence",
+    "Use `all_of(vars)` instead of `vars` to silence",
     fixed = TRUE
   )
   verify_output(test_path("outputs", "vars-select-context-lookup.txt"), {

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -162,3 +162,20 @@ test_that("non-strict evaluation allows unknown variables", {
     vars_select(letters, -int())
   )
 })
+
+test_that("can use predicates in selections", {
+  expect_identical(select_pos(iris, is.factor), c(Species = 5L))
+  expect_identical(select_pos(iris, is.numeric), set_names(1:4, names(iris)[1:4]))
+})
+
+test_that("predicates have access to the full data", {
+  p <- function(x) is.numeric(x) && mean(x) > 5
+  expect_identical(select_pos(iris, p), c(Sepal.Length = 1L))
+})
+
+test_that("informative error with legacy tidyselect", {
+  expect_error(
+    vars_select(letters, is.numeric),
+    "doesn't support predicates yet"
+  )
+})

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -97,9 +97,9 @@ test_that("scalar boolean operators fail informatively", {
   })
 })
 
-test_that("can't use boolean operators with symbols", {
-  expect_error(vars_select(letters, starts_with("a") & z), "bare variables")
-  expect_error(vars_select(letters, starts_with("a") | z), "bare variables")
+test_that("boolean operators evaluate symbols outside the data", {
+  expect_error(vars_select(letters, starts_with("a") & z), "not found")
+  expect_error(vars_select(letters, starts_with("a") | z), "not found")
 
   verify_output(test_path("outputs", "vars-select-bool-symbols.txt"), {
     vars_select(letters, starts_with("a") & z)
@@ -166,6 +166,8 @@ test_that("non-strict evaluation allows unknown variables", {
 test_that("can use predicates in selections", {
   expect_identical(select_pos(iris, is.factor), c(Species = 5L))
   expect_identical(select_pos(iris, is.numeric), set_names(1:4, names(iris)[1:4]))
+  expect_identical(select_pos(iris, is.numeric & is.factor), set_names(int(), chr()))
+  expect_identical(select_pos(iris, is.numeric | is.factor), set_names(1:5, names(iris)))
 })
 
 test_that("inline functions are allowed", {

--- a/tests/testthat/test-vars-select-eval.R
+++ b/tests/testthat/test-vars-select-eval.R
@@ -168,6 +168,17 @@ test_that("can use predicates in selections", {
   expect_identical(select_pos(iris, is.numeric), set_names(1:4, names(iris)[1:4]))
 })
 
+test_that("inline functions are allowed", {
+  expect_identical(
+    select_pos(iris, !!is.numeric),
+    select_pos(iris, is.numeric),
+  )
+  expect_identical(
+    select_pos(iris, function(x) is.numeric(x)),
+    select_pos(iris, is.numeric),
+  )
+})
+
 test_that("predicates have access to the full data", {
   p <- function(x) is.numeric(x) && mean(x) > 5
   expect_identical(select_pos(iris, p), c(Sepal.Length = 1L))


### PR DESCRIPTION
Part of #89 and closes #86.

* Takes a vector or data frame and returns a vector of selected positions. Because it takes the whole data as input, it supports predicate selections. Because it returns a vector of positions rather than names, it has better support for duplicated names.

* Unexported `vec_select()` serves as an implementation example. While `vec_select()` has vctrs semantics (but refuses to work with data frames), `select_pos()` has `[` semantics and works with data frames. This should make it easier for packages like tidyr to interface with it.

* Selections are taken via `...` for now, because `c(...)` isn't consistent with `...` yet.

* Will be documented and exported later on when `c(...)` has been fixed. We will switch to a single named parameter to encourage tidyr-like interfaces, which should be more common than dplyr-like ones.