### PR TITLE
Sanitise base errors

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,13 +1,7 @@
 
 subclass_index_errors <- function(expr, allow_positions = TRUE) {
   tryCatch(
-    withCallingHandlers(
-      expr,
-      simpleError = function(cnd) {
-        # Pass `cnd` as parent to ensure proper backtraces
-        abort(conditionMessage(cnd), parent = cnd)
-      }
-    ),
+    sanitise_base_errors(expr),
     vctrs_error_index_oob_names = function(cnd) {
       stop_index_oob(parent = cnd, .subclass = "tidyselect_error_index_oob_names")
     },
@@ -19,6 +13,15 @@ subclass_index_errors <- function(expr, allow_positions = TRUE) {
     },
     vctrs_error_names_must_be_unique = function(cnd) {
       stop_names_must_be_unique(parent = cnd)
+    }
+  )
+}
+sanitise_base_errors <- function(expr) {
+  withCallingHandlers(
+    expr,
+    simpleError = function(cnd) {
+      # Pass `cnd` as parent to ensure proper backtraces
+      abort(conditionMessage(cnd), parent = cnd)
     }
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,7 +1,13 @@
 
 subclass_index_errors <- function(expr, allow_positions = TRUE) {
   tryCatch(
-    expr,
+    withCallingHandlers(
+      expr,
+      simpleError = function(cnd) {
+        # Pass `cnd` as parent to ensure proper backtraces
+        abort(conditionMessage(cnd), parent = cnd)
+      }
+    ),
     vctrs_error_index_oob_names = function(cnd) {
       stop_index_oob(parent = cnd, .subclass = "tidyselect_error_index_oob_names")
     },

--- a/R/vars-rename.R
+++ b/R/vars-rename.R
@@ -61,7 +61,9 @@ vars_rename_eval <- function(quos, vars) {
     mask <- NULL
   }
 
-  map(quos, expr_rename_eval, mask)
+  sanitise_base_errors(
+    map(quos, expr_rename_eval, mask)
+  )
 }
 
 expr_rename_eval <- function(quo, mask) {

--- a/tests/testthat/outputs/eval-errors.txt
+++ b/tests/testthat/outputs/eval-errors.txt
@@ -1,4 +1,4 @@
 > # Foreign errors during evaluation
 > select_pos(iris, eval_tidy(foobar))
-Error in eval_tidy(foobar): object 'foobar' not found
+Error: object 'foobar' not found
 

--- a/tests/testthat/outputs/eval-errors.txt
+++ b/tests/testthat/outputs/eval-errors.txt
@@ -1,0 +1,4 @@
+> # Foreign errors during evaluation
+> select_pos(iris, eval_tidy(foobar))
+Error in eval_tidy(foobar): object 'foobar' not found
+

--- a/tests/testthat/outputs/rename-strict-errors.txt
+++ b/tests/testthat/outputs/rename-strict-errors.txt
@@ -1,8 +1,8 @@
 > vars_rename(c("a", "b"), d = e, .strict = TRUE)
-Error in eval_tidy(quo, mask): object 'e' not found
+Error: object 'e' not found
 
 > vars_rename(c("a", "b"), d = e, f = g, .strict = TRUE)
-Error in eval_tidy(quo, mask): object 'e' not found
+Error: object 'e' not found
 
 > vars_rename(c("a", "b"), d = "e", f = "g", .strict = TRUE)
 Error: Must select existing columns.

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -236,3 +236,10 @@ test_that("unique elements are returned", {
   expect_identical(select_pos(x, !!c(foo = 1L, 1L)), c(foo = 1L))
   expect_identical(select_pos(x, !!c(foo = 1L, 1L, bar = 1L)), c(foo = 1L, bar = 1L))
 })
+
+test_that("selections provide informative errors", {
+  verify_output(test_path("outputs", "eval-errors.txt"), {
+    "Foreign errors during evaluation"
+    select_pos(iris, eval_tidy(foobar))
+  })
+})


### PR DESCRIPTION
This prevents the function calls from leaking into base errors during evaluation.

Before:

```r
#> Error in eval_tidy(quo, mask): object 'e' not found
```

After:

```r
#> Error: object 'e' not found
```

We should probably use this approach in all data masking APIs, such as in dplyr. cc @batpigandme and @romainfrancois 