### PR TITLE
Add missing comma to remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     testthat (>= 2.3.0),
     tibble (>= 2.1.3)
 remotes:
-    r-lib/vctrs
+    r-lib/vctrs,
     r-lib/rlang
 License: GPL-3
 Encoding: UTF-8


### PR DESCRIPTION
Fixes installation error
```r
remotes::install_github("r-lib/tidyselect")
#> Downloading GitHub repo r-lib/tidyselect@master
#> Error: Failed to install 'tidyselect' from GitHub:
#>   Missing commas separating Remotes: 'r-lib/vctrs
#>     r-lib/rlang'
```