### PR TITLE
Delay naming of predicate check output

### DIFF
--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -145,7 +145,7 @@ as_indices_sel_impl <- function(x, vars, strict, data = NULL) {
     }
     predicate <- x
     x <- which(map_lgl(data, predicate))
-    #x <- set_names(x, NULL)
+    x <- set_names(x, NULL)
   }
 
   as_indices_impl(x, vars, strict = strict)

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -145,7 +145,7 @@ as_indices_sel_impl <- function(x, vars, strict, data = NULL) {
     }
     predicate <- x
     x <- which(map_lgl(data, predicate))
-    x <- set_names(x, NULL)
+    #x <- set_names(x, NULL)
   }
 
   as_indices_impl(x, vars, strict = strict)

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -145,6 +145,7 @@ as_indices_sel_impl <- function(x, vars, strict, data = NULL) {
     }
     predicate <- x
     x <- which(map_lgl(data, predicate))
+    x <- set_names(x, NULL)
   }
 
   as_indices_impl(x, vars, strict = strict)

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -387,3 +387,10 @@ test_that("can rename before predicate", {
   expect_equal(head(names(selection), 1), "y")
 
 })
+
+test_that("data names aren't retained when renaming with predicate", {
+  expect_identical(
+    eval_rename(expr(c(foo = where(~ all(.x %in% 0:1)))), mtcars),
+    c(foo1 = 8L, foo2 = 9L)
+  )
+})

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -361,9 +361,29 @@ test_that("can use predicates with allow_rename = FALSE", {
   )
 })
 
-test_that("no duplicates with predicate and user rename", {
+test_that("can rename after predicate", {
+  selection <- eval_select(expr(c(where(is.numeric), y = mpg)), mtcars)
+
+  "no duplicate columns"
   expect_equal(
-    ncol(eval_select(expr(c(where(is.numeric), y = mpg)), mtcars)),
+    ncol(selection),
     ncol(eval_select(expr(where(is.numeric)), mtcars))
   )
+
+  "var is renamed"
+  expect_equal(head(names(selection), 1), "y")
+})
+
+test_that("can rename before predicate", {
+  selection <- eval_select(expr(c(y = mpg, where(is.numeric))), mtcars)
+
+  "no duplicate columns"
+  expect_equal(
+    ncol(selection),
+    ncol(eval_select(expr(where(is.numeric)), mtcars))
+  )
+
+  "var is renamed"
+  expect_equal(head(names(selection), 1), "y")
+
 })

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -353,3 +353,10 @@ test_that("eval_walk() has informative messages", {
                          is.numeric(.x) || is.factor(.x) || is.character(.x))
   })
 })
+
+test_that("can use predicates with allow_rename = FALSE", {
+  expect_equal(
+    select_loc(mtcars, where(is.numeric), allow_rename = FALSE),
+    seq_along(mtcars)
+  )
+})

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -360,3 +360,10 @@ test_that("can use predicates with allow_rename = FALSE", {
     seq_along(mtcars)
   )
 })
+
+test_that("no duplicates with predicate and user rename", {
+  expect_equal(
+    ncol(eval_select(expr(c(where(is.numeric), y = mpg)), mtcars)),
+    ncol(eval_select(expr(where(is.numeric)), mtcars))
+  )
+})


### PR DESCRIPTION
closes #225 
closes #215
closes #204

I removed the names from `map_lgl(data, predicate)` output in `as_indices_sel_impl`. The predicate-produced part of the `pos` vector will be given empty-string names by `loc_validate` afterwards. If `allow_rename = FALSE` then having the data's names isn't needed. If `allow_rename = TRUE` then the data's names are added back in `ensure_named` where needed.
