### PR TITLE
Empty selections don't error with `allow_rename = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyselect (development version)
 
+* `eval_select(allow_rename = FALSE)` no longer fails with empty
+  selections (#221, @eutwt).
+
 * `where()` is now exported, like all other select helpers (#201).
 
 * Fixed error when selecting with predicates and `allow_rename =

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -95,7 +95,7 @@ ensure_named <- function(pos,
                          allow_rename,
                          call) {
   if (!allow_rename) {
-    if (is_named(pos)) {
+    if (is_named(pos) && !is_empty(pos)) {
       abort("Can't rename variables in this context.", call = call)
     }
     return(set_names(pos, NULL))

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -345,3 +345,7 @@ test_that("eval_walk() has informative messages", {
     (expect_error(select_loc(mtcars, .data$"foo")))
   })
 })
+
+test_that("can make empty selection with allow_rename = FALSE", {
+  expect_identical(select_loc(mtcars, character(), allow_rename = FALSE), integer(0))
+})


### PR DESCRIPTION
closes #221 

Thanks to @DavisVaughan for suggestion to use `is_empty`