### PR TITLE
Use `local_bindings()` instead of `scoped_bindings()`

### DIFF
--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -104,7 +104,7 @@ walk_data_tree <- function(expr, data_mask, context_mask, colon = FALSE) {
   # mask, so we can evaluate the expression in the correct context
   # later on.
   if (is_quosure(expr)) {
-    scoped_bindings(.__current__. = quo_get_env(expr), .env = context_mask)
+    local_bindings(.__current__. = quo_get_env(expr), .env = context_mask)
     expr <- quo_get_expr2(expr, expr)
   }
 


### PR DESCRIPTION
Closes #254

```r
Warning messages:
`scoped_bindings()` is deprecated as of rlang 0.4.2.
Please use `local_bindings()` instead.
```