### PR TITLE
add protection against passing vector offset=

### DIFF
--- a/R/helpers-misc.R
+++ b/R/helpers-misc.R
@@ -61,7 +61,7 @@ everything <- function(vars = NULL) {
 #' @export
 #' @param offset Set it to `n` to select the nth var from the end.
 last_col <- function(offset = 0L, vars = NULL) {
-  stopifnot(is_integerish(offset))
+  stopifnot(is_integerish(offset), length(offset) == 1L)
 
   vars <- vars %||% peek_vars(fn = "last_col")
   n <- length(vars)

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -256,6 +256,7 @@ test_that("last_col() selects last argument with offset", {
 
   expect_error(last_col(3, vars), "`offset` must be smaller than the number of columns")
   expect_error(last_col(vars = chr()), "Can't select last column when input is empty")
+  expect_error(last_col(1:3, vars), "length(offset) == 1 is not TRUE", fixed = TRUE)
 })
 
 test_that("all_of() and any_of() handle named vectors", {


### PR DESCRIPTION
As used mistakenly in a test here:

https://github.com/tidymodels/broom/issues/1077