### PR TITLE
Test renaming predicates

### DIFF
--- a/tests/testthat/_snaps/eval-rename.md
+++ b/tests/testthat/_snaps/eval-rename.md
@@ -1,3 +1,11 @@
+# rename_loc() works with predicate functions
+
+    Code
+      rename_loc(x, where(is.numeric))
+    Condition
+      Error in `rename_loc()`:
+      ! All renaming inputs must be named.
+
 # rename_loc() throws helpful errors
 
     Code

--- a/tests/testthat/test-eval-rename.R
+++ b/tests/testthat/test-eval-rename.R
@@ -70,6 +70,12 @@ test_that("rename_loc() allows fixing duplicates by locations", {
   )
 })
 
+test_that("rename_loc() works with predicate functions", {
+  x <- data.frame(a = 1, b = 2, c = "x", stringsAsFactors = FALSE)
+  expect_equal(rename_loc(x, c(var = where(is.numeric))), c(var1 = 1, var2 = 2))
+  expect_snapshot(rename_loc(x, where(is.numeric)), error = TRUE)
+})
+
 test_that("rename_loc() requires named inputs", {
   expect_error(rename_loc(iris, Species), "named")
   expect_error(rename_loc(iris, c(contains("Width"))), "named")

--- a/tests/testthat/test-eval-select.R
+++ b/tests/testthat/test-eval-select.R
@@ -149,3 +149,9 @@ test_that("middle (no-match) selector should not clear previous selectors (issue
     c(x = 1L, z = 3L)
   )
 })
+
+test_that("selecting with predicate + rename doesn't duplicate", {
+  x <- list(a = "x", b = "y", c = 1, d = 2)
+  expect_equal(select_loc(x, c(where(is.numeric), C = c)), c(C = 3, d = 4))
+  expect_equal(select_loc(x, c(where(is.numeric), A = a)), c(c = 3, d = 4, A = 1))
+})


### PR DESCRIPTION
This closes #204 and #215, confirming that they were fixed incidentally in be45ce0ba650e94d37b681537e55df652421fa0f.
