### PR TITLE
Add a class to the rename error and rethrow it in `eval_relocate()`

### DIFF
--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -107,12 +107,16 @@ eval_relocate <- function(expr,
   }
 
   if (has_before) {
-    where <- eval_select(
-      expr = before,
-      data = data,
-      env = env,
-      error_call = error_call,
-      allow_rename = FALSE
+    where <- with_rename_errors(
+      eval_select(
+        expr = before,
+        data = data,
+        env = env,
+        error_call = error_call,
+        allow_rename = FALSE
+      ),
+      arg = before_arg,
+      error_call = error_call
     )
     where <- unname(where)
 
@@ -123,12 +127,16 @@ eval_relocate <- function(expr,
       where <- min(where)
     }
   } else if (has_after) {
-    where <- eval_select(
-      expr = after,
-      data = data,
-      env = env,
-      error_call = error_call,
-      allow_rename = FALSE
+    where <- with_rename_errors(
+      eval_select(
+        expr = after,
+        data = data,
+        env = env,
+        error_call = error_call,
+        allow_rename = FALSE
+      ),
+      arg = after_arg,
+      error_call = error_call
     )
     where <- unname(where)
 
@@ -160,4 +168,16 @@ eval_relocate <- function(expr,
   sel <- vctrs::vec_c(lhs, sel, rhs)
 
   sel
+}
+
+with_rename_errors <- function(expr, arg, error_call) {
+  tryCatch(
+    expr,
+    tidyselect_error_disallowed_rename = function(cnd) {
+      cli::cli_abort(
+        "Can't rename variables when specifying {.arg {arg}}.",
+        call = error_call
+      )
+    }
+  )
 }

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -171,7 +171,7 @@ eval_relocate <- function(expr,
 }
 
 with_rename_errors <- function(expr, arg, error_call) {
-  tryCatch(
+  try_fetch(
     expr,
     tidyselect_error_disallowed_rename = function(cnd) {
       cli::cli_abort(

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -175,7 +175,7 @@ with_rename_errors <- function(expr, arg, error_call) {
     expr,
     `tidyselect:::error_disallowed_rename` = function(cnd) {
       cli::cli_abort(
-        "Can't rename variables when specifying {.arg {arg}}.",
+        "Can't rename variables when {.arg {arg}} is supplied.",
         call = error_call
       )
     }

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -173,7 +173,7 @@ eval_relocate <- function(expr,
 with_rename_errors <- function(expr, arg, error_call) {
   try_fetch(
     expr,
-    tidyselect_error_disallowed_rename = function(cnd) {
+    `tidyselect:::error_disallowed_rename` = function(cnd) {
       cli::cli_abort(
         "Can't rename variables when specifying {.arg {arg}}.",
         call = error_call

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -104,7 +104,11 @@ ensure_named <- function(pos,
 
   if (!allow_rename) {
     if (is_named(pos) && !is_empty(pos)) {
-      cli::cli_abort("Can't rename variables in this context.", call = call)
+      cli::cli_abort(
+        "Can't rename variables in this context.",
+        class = "tidyselect_error_disallowed_rename",
+        call = call
+      )
     }
     pos
   }

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -106,7 +106,7 @@ ensure_named <- function(pos,
     if (is_named(pos) && !is_empty(pos)) {
       cli::cli_abort(
         "Can't rename variables in this context.",
-        class = "tidyselect_error_disallowed_rename",
+        class = "tidyselect:::error_disallowed_rename",
         call = call
       )
     }

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -61,13 +61,13 @@
     Code
       (expect_error(relocate_loc(x, c(foo = b), allow_rename = FALSE)))
     Output
-      <error/tidyselect_error_disallowed_rename>
+      <error/tidyselect:::error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
     Code
       (expect_error(relocate_loc(x, c(b, foo = b), allow_rename = FALSE)))
     Output
-      <error/tidyselect_error_disallowed_rename>
+      <error/tidyselect:::error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
 

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -99,23 +99,23 @@
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables when specifying `before`.
+      ! Can't rename variables when `before` is supplied.
     Code
       (expect_error(relocate_loc(x, b, before = c(new = c), before_arg = ".before")))
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables when specifying `.before`.
+      ! Can't rename variables when `.before` is supplied.
     Code
       (expect_error(relocate_loc(x, b, after = c(new = c))))
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables when specifying `after`.
+      ! Can't rename variables when `after` is supplied.
     Code
       (expect_error(relocate_loc(x, b, after = c(new = c), after_arg = ".after")))
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables when specifying `.after`.
+      ! Can't rename variables when `.after` is supplied.
 

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -61,13 +61,13 @@
     Code
       (expect_error(relocate_loc(x, c(foo = b), allow_rename = FALSE)))
     Output
-      <error/rlang_error>
+      <error/tidyselect_error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
     Code
       (expect_error(relocate_loc(x, c(b, foo = b), allow_rename = FALSE)))
     Output
-      <error/rlang_error>
+      <error/tidyselect_error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
 
@@ -99,11 +99,23 @@
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when specifying `before`.
+    Code
+      (expect_error(relocate_loc(x, b, before = c(new = c), before_arg = ".before")))
+    Output
+      <error/rlang_error>
+      Error in `relocate_loc()`:
+      ! Can't rename variables when specifying `.before`.
     Code
       (expect_error(relocate_loc(x, b, after = c(new = c))))
     Output
       <error/rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when specifying `after`.
+    Code
+      (expect_error(relocate_loc(x, b, after = c(new = c), after_arg = ".after")))
+    Output
+      <error/rlang_error>
+      Error in `relocate_loc()`:
+      ! Can't rename variables when specifying `.after`.
 

--- a/tests/testthat/_snaps/eval-select.md
+++ b/tests/testthat/_snaps/eval-select.md
@@ -26,13 +26,13 @@
     Code
       (expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)))
     Output
-      <error/tidyselect_error_disallowed_rename>
+      <error/tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
     Code
       (expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)))
     Output
-      <error/tidyselect_error_disallowed_rename>
+      <error/tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
 

--- a/tests/testthat/_snaps/eval-select.md
+++ b/tests/testthat/_snaps/eval-select.md
@@ -21,6 +21,21 @@
       Error in `select_loc()`:
       ! `include` must be a character vector.
 
+# can forbid rename syntax (#178)
+
+    Code
+      (expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)))
+    Output
+      <error/tidyselect_error_disallowed_rename>
+      Error in `select_loc()`:
+      ! Can't rename variables in this context.
+    Code
+      (expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)))
+    Output
+      <error/tidyselect_error_disallowed_rename>
+      Error in `select_loc()`:
+      ! Can't rename variables in this context.
+
 # can forbid empty selections
 
     Code

--- a/tests/testthat/test-eval-relocate.R
+++ b/tests/testthat/test-eval-relocate.R
@@ -187,6 +187,9 @@ test_that("`before` and `after` forbid renaming", {
 
   expect_snapshot({
     (expect_error(relocate_loc(x, b, before = c(new = c))))
+    (expect_error(relocate_loc(x, b, before = c(new = c), before_arg = ".before")))
+
     (expect_error(relocate_loc(x, b, after = c(new = c))))
+    (expect_error(relocate_loc(x, b, after = c(new = c), after_arg = ".after")))
   })
 })

--- a/tests/testthat/test-eval-select.R
+++ b/tests/testthat/test-eval-select.R
@@ -87,8 +87,11 @@ test_that("result is named even with constant inputs (#173)", {
 })
 
 test_that("can forbid rename syntax (#178)", {
-  expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE), "Can't rename")
-  expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE), "Can't rename")
+  expect_snapshot({
+    (expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)))
+    (expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)))
+  })
+
   expect_named(select_loc(mtcars, starts_with("c") | all_of("am"), allow_rename = FALSE), c("cyl", "carb", "am"))
 })
 


### PR DESCRIPTION
Closes #298 

I didn't add a class to the rethrown error. It seems like the class is just meant for internal use, and I don't see us needing to ever rethrow the already rethrown error, so I didn't think it needed a class.