### PR TITLE
Use the new `"select"` and `"relocate"` subscript actions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
     testthat (>= 3.1.1),
     tibble (>= 2.1.3)
 Remotes:
-    r-lib/vctrs#1619
+    r-lib/vctrs
 VignetteBuilder:
     knitr
 ByteCompile: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     cli (>= 3.3.0),
     glue (>= 1.3.0),
     rlang (>= 1.0.4),
-    vctrs (>= 0.4.1),
+    vctrs (>= 0.4.1.9000),
     withr
 Suggests:
     covr,
@@ -31,6 +31,8 @@ Suggests:
     stringr,
     testthat (>= 3.1.1),
     tibble (>= 2.1.3)
+Remotes:
+    r-lib/vctrs#1619
 VignetteBuilder:
     knitr
 ByteCompile: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyselect (development version)
 
+* `eval_select()` out-of-bounds errors now use the verb "select" rather than
+  "subset" in the error message for consistency with `dplyr::select()` (#271).
+
 * New `eval_relocate()` for moving a selection. This powers `dplyr::relocate()`
   (#232).
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -30,12 +30,13 @@ subscript_action <- function(type) {
   switch(validate_type(type),
     select = "select",
     rename = "rename",
+    relocate = "relocate",
     pull = "extract"
   )
 }
 validate_type <- function(type) {
   # We might add `recode` in the future
-  if (!is_string(type, c("select", "rename", "pull"))) {
+  if (!is_string(type, c("select", "rename", "relocate", "pull"))) {
     cli::cli_abort("Unexpected value for {.arg tidyselect_type}.", .internal = TRUE)
   }
   type

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,6 +1,4 @@
-with_subscript_errors <- function(expr,
-                                  type = "select",
-                                  call = caller_env()) {
+with_subscript_errors <- function(expr, type = "select") {
   try_fetch(
     expr,
     vctrs_error_subscript = function(cnd) {
@@ -30,7 +28,7 @@ with_chained_errors <- function(expr, action, call, eval_expr = NULL) {
 
 subscript_action <- function(type) {
   switch(validate_type(type),
-    select = "subset",
+    select = "select",
     rename = "rename",
     pull = "extract"
   )

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -73,14 +73,17 @@ eval_relocate <- function(expr,
                           error_call = caller_env()) {
   check_dots_empty()
 
-  sel <- eval_select(
+  expr <- as_quosure(expr, env = env)
+
+  sel <- eval_select_impl(
+    x = data,
+    names = names(data),
     expr = expr,
-    data = data,
-    env = env,
     strict = strict,
     name_spec = name_spec,
     allow_rename = allow_rename,
     allow_empty = allow_empty,
+    type = "relocate",
     error_call = error_call
   )
 

--- a/tests/testthat/_snaps/eval-bool.md
+++ b/tests/testthat/_snaps/eval-bool.md
@@ -5,13 +5,13 @@
       select_loc(mtcars, foobar & contains("am"))
     Condition
       Error in `select_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foobar` doesn't exist.
     Code
       select_loc(mtcars, contains("am") | foobar)
     Condition
       Error in `select_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foobar` doesn't exist.
     Code
       # Empty intersection
@@ -26,6 +26,6 @@
       select_loc(iris, Species | foo)
     Condition
       Error in `select_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foo` doesn't exist.
 

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -22,8 +22,16 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't select columns that don't exist.
+      ! Can't relocate columns that don't exist.
       x Column `c` doesn't exist.
+    Code
+      (expect_error(relocate_loc(x, c(1, 3))))
+    Output
+      <error/vctrs_error_subscript_oob>
+      Error in `relocate_loc()`:
+      ! Can't relocate columns that don't exist.
+      i Location 3 doesn't exist.
+      i There are only 2 columns.
     Code
       (expect_error(relocate_loc(x, a, before = c)))
     Output

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -22,21 +22,21 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
     Code
       (expect_error(relocate_loc(x, a, before = c)))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
     Code
       (expect_error(relocate_loc(x, a, after = c)))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
 
 # can relocate with out-of-bounds variables in `expr` if `strict = FALSE`
@@ -46,14 +46,14 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
     Code
       (expect_error(relocate_loc(x, a, after = c, strict = FALSE)))
     Output
       <error/vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
 
 # can forbid rename syntax

--- a/tests/testthat/_snaps/lifecycle-deprecated.md
+++ b/tests/testthat/_snaps/lifecycle-deprecated.md
@@ -4,20 +4,20 @@
       vars_select(letters, TRUE)
     Condition
       Error:
-      ! Must subset columns with a valid subscript vector.
+      ! Must select columns with a valid subscript vector.
       x Subscript has the wrong type `logical`.
       i It must be numeric or character.
     Code
       vars_select(letters, 2.5)
     Condition
       Error:
-      ! Must subset columns with a valid subscript vector.
+      ! Must select columns with a valid subscript vector.
       x Can't convert from <double> to <integer> due to loss of precision.
     Code
       vars_select(letters, structure(1:3, class = "tidysel_foobar"))
     Condition
       Error:
-      ! Must subset columns with a valid subscript vector.
+      ! Must select columns with a valid subscript vector.
       x Subscript has the wrong type `tidysel_foobar`.
       i It must be numeric or character.
 
@@ -28,47 +28,47 @@
       vars_select(letters, foo)
     Condition
       Error:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foo` doesn't exist.
     Code
       vars_select(letters, -foo)
     Condition
       Error:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foo` doesn't exist.
     Code
       # Names
       vars_select(letters, "foo")
     Condition
       Error:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foo` doesn't exist.
     Code
       vars_select(letters, a:"foo")
     Condition
       Error:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `foo` doesn't exist.
     Code
       # Locations
       vars_select(letters, 30, 50, 100)
     Condition
       Error:
-      ! Can't subset columns past the end.
+      ! Can't select columns past the end.
       i Locations 30, 50, and 100 don't exist.
       i There are only 26 columns.
     Code
       vars_select(letters, -100)
     Condition
       Error:
-      ! Can't subset columns past the end.
+      ! Can't select columns past the end.
       i Location 100 doesn't exist.
       i There are only 26 columns.
     Code
       vars_select(letters, !100)
     Condition
       Error:
-      ! Can't subset columns past the end.
+      ! Can't select columns past the end.
       i Location 100 doesn't exist.
       i There are only 26 columns.
 

--- a/tests/testthat/_snaps/vars-pull.md
+++ b/tests/testthat/_snaps/vars-pull.md
@@ -29,14 +29,14 @@
     Code
       vars_pull(letters, 100)
     Condition
-      Error in `vec_as_location2_result()`:
+      Error:
       ! Can't extract columns past the end.
       i Location 100 doesn't exist.
       i There are only 26 columns.
     Code
       vars_pull(letters, -100)
     Condition
-      Error in `vec_as_location2_result()`:
+      Error:
       ! Can't extract columns past the end.
       i Location 100 doesn't exist.
       i There are only 26 columns.
@@ -69,7 +69,7 @@
     Code
       vars_pull(letters, "foo")
     Condition
-      Error in `vec_as_location2_result()`:
+      Error:
       ! Can't extract columns that don't exist.
       x Column `foo` doesn't exist.
 

--- a/tests/testthat/test-eval-relocate.R
+++ b/tests/testthat/test-eval-relocate.R
@@ -130,6 +130,7 @@ test_that("can't relocate with out-of-bounds variables by default", {
 
   expect_snapshot({
     (expect_error(relocate_loc(x, c)))
+    (expect_error(relocate_loc(x, c(1, 3))))
     (expect_error(relocate_loc(x, a, before = c)))
     (expect_error(relocate_loc(x, a, after = c)))
   })


### PR DESCRIPTION
Closes #271 
Requires https://github.com/r-lib/vctrs/pull/1619 (I'll merge that first and then update here)

Note that this means tidyselect now relies on dev vctrs.