### PR TITLE
Use soft deprecation everywhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
   `.data[[var]]` with `any_of(var)` or `all_of(var)` (#169).
 
 * Use of bare predicates (not wrapped in `where()`) and indirection (without
-  using `all_of()`) now warn on every use (#317).
+  using `all_of()`) have been formally deprecated (#317).
 
 ## Minor improvements and bug fixes
 

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -400,7 +400,8 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
       return(name)
     }
 
-    lifecycle::deprecate_warn("1.1.0",
+    # Formally deprecated in 1.2.0
+    lifecycle::deprecate_soft("1.1.0",
       what = I("Use of bare predicate functions"),
       with = I("wrap predicates in `where()`"),
       details = paste_lines(
@@ -409,8 +410,7 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
         "",
         "  # Now:",
         glue("  data %>% select(where({name}))")
-      ),
-      always = TRUE
+      )
     )
 
     return(value)
@@ -421,7 +421,8 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
     return(name)
   }
 
-  lifecycle::deprecate_warn("1.1.0",
+  # Formally deprecated in 1.2.0
+  lifecycle::deprecate_soft("1.1.0",
     I("Using an external vector in selections"),
     I("`all_of()` or `any_of()`"),
     details = paste_lines(
@@ -432,8 +433,7 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
       glue("  data %>% select(all_of({name}))"),
       "",
       "See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>."
-    ),
-    always = TRUE
+    )
   )
 
   value


### PR DESCRIPTION
While exploring dplyr revdeps these still seem to be used in a lot of places, and I think the previous `cli_inform()`/`cli_warn()` was probably easy to miss because they didn't appear in every test.

Fixes #319