### PR TITLE
Update deprecation message

### DIFF
--- a/R/helpers-vector.R
+++ b/R/helpers-vector.R
@@ -78,7 +78,7 @@ all_of <- function(x) {
     lifecycle::deprecate_soft(
       "1.2.0",
       I("Using `all_of()` outside of a selecting function"),
-      details = paste0("See details at", peek_vars_link())
+      details = paste("See details at", peek_vars_link())
     )
     return(x)
   }

--- a/tests/testthat/_snaps/helpers-vector.md
+++ b/tests/testthat/_snaps/helpers-vector.md
@@ -81,7 +81,7 @@
     Condition
       Warning:
       Using `all_of()` outside of a selecting function was deprecated in tidyselect 1.2.0.
-      See details at<https://tidyselect.r-lib.org/reference/faq-selection-context.html>
+      See details at <https://tidyselect.r-lib.org/reference/faq-selection-context.html>
 
 # any_of generates informative error if ... not empty
 


### PR DESCRIPTION
I am prepping some of my packages for the updates in tidyselect v1.2.0, and noticed the deprecation message was missing a space between the text and the link to the `?tidyselect::faq-selection-context` document. 🍁 

```
Warning message:
Using `all_of()` outside of a selecting function was deprecated in <NA> 1.2.0.
See details at?tidyselect::faq-selection-context
```