### PR TITLE
Attempt names propagation only when necessary in set ops

### DIFF
--- a/R/sets.R
+++ b/R/sets.R
@@ -2,25 +2,28 @@
 # The `sel_` prefixed operations match on both values and names, with
 # unnamed elements matching named ones
 sel_union <- function(x, y) {
-  if (is_null(names(x)) && is_null(names(y))) {
-    set_union(x, y)
-  } else {
+  if (any_valid_names(names(x)) || any_valid_names(names(y))) {
     sel_operation(x, y, set_union)
+  } else {
+    set_union(x, y)
   }
 }
 sel_intersect <- function(x, y) {
-  if (is_null(names(x)) && is_null(names(y))) {
-    set_intersect(x, y)
-  } else {
+  if (any_valid_names(names(x)) || any_valid_names(names(y))) {
     sel_operation(x, y, set_intersect)
+  } else {
+    set_intersect(x, y)
   }
 }
 sel_unique <- function(x) {
-  x <- vctrs::new_data_frame(list(value = x, names = names2(x)))
-  x <- propagate_names(x)
-
-  out <- vctrs::vec_unique(x)
-  set_names(out$value, out$names)
+  if (any_valid_names(names(x))) {
+    x <- vctrs::new_data_frame(list(value = x, names = names2(x)))
+    x <- propagate_names(x)
+    out <- vctrs::vec_unique(x)
+    set_names(out$value, out$names)
+  } else {
+    vctrs::vec_unique(x)
+  }
 }
 
 # Set difference and set complement must validate their RHS eagerly,
@@ -29,10 +32,10 @@ sel_diff <- function(x, y, vars = NULL, error_call = caller_env()) {
   if (!is_null(vars)) {
     y <- loc_validate(y, vars, call = error_call)
   }
-  if (is_null(names(x)) || is_null(names(y))) {
-    set_diff(x, y)
-  } else {
+  if (any_valid_names(names(x)) && any_valid_names(names(y))) {
     sel_operation(x, y, set_diff)
+  } else {
+    set_diff(x, y)
   }
 }
 sel_complement <- function(x, vars = NULL, error_call = caller_env()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,6 +71,14 @@ relocate_loc <- function(x,
   )
 }
 
+any_valid_names <- function(nms) {
+  if (is_null(nms)) {
+    FALSE
+  } else {
+    !all(are_empty_name(nms))
+  }
+}
+
 are_empty_name <- function(nms) {
   if (!is_character(nms)) {
     abort("Expected a character vector")


### PR DESCRIPTION
A `profvis()` of this common `c()` case of `eval_select()` shows that one of the biggest performance hits comes from `names_propagate()` inside of the `sel_*()` set ops.

It looks like even an expression like `c(mpg, cyl)` ends up going through the names propagation path, which doesn't seem right (there aren't names to propagate here).

This ends up happening because the `eval_c()` "reduce" path starts with a base `named(int())` value and then unions that with the result of each node, like `mpg` and `cyl`. But the fact that `named(int())` is named at all causes the name propagation path to fire.

I've tweaked this so that deciding whether or not to try names propagation works off `any_valid_names()`, which only returns `TRUE` if:
- Names are not `NULL`
- At least one name is not `""` or `NA`

This way two vectors with empty names don't cause name propagation to be attempted.

This ends up having around a 25% performance boost for this simple case, which is nice!

``` r
library(tidyselect)
library(rlang)

expr <- expr(c(mpg, cyl))

bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN tidyselect
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    974µs   1.12ms      867.    5.37MB     12.7

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    763µs    857µs     1119.    5.86MB     13.0
```

<sup>Created on 2023-03-07 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>