### PR TITLE
Specify `default` to speed up symbol lookup

### DIFF
--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -389,11 +389,11 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
   top <- data_mask$.top_env
   cur <- data_mask
   value <- missing_arg()
-  sentinel <- missing_sentinel()
   while (!is_reference(cur, top)) {
-    candidate <- env_get(cur, name, default = sentinel)
-    if (!is_missing_sentinel(candidate)) {
-      value <- candidate
+    if (env_has(cur, name)) {
+      # TODO: Remove unnecessary `default` specification after
+      # https://github.com/r-lib/rlang/issues/1582
+      value <- env_get(cur, name, default = NULL)
       break
     }
     cur <- env_parent(cur)
@@ -458,16 +458,6 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
   )
 
   value
-}
-
-is_missing_sentinel <- function(x) {
-  inherits(x, "tidyselect:::missing_sentinel")
-}
-missing_sentinel <- function() {
-  # Much faster than `structure()`
-  out <- list()
-  class(out) <- "tidyselect:::missing_sentinel"
-  out
 }
 
 validate_dot_data <- function(expr, call) {

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -389,9 +389,11 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
   top <- data_mask$.top_env
   cur <- data_mask
   value <- missing_arg()
+  sentinel <- missing_sentinel()
   while (!is_reference(cur, top)) {
-    if (env_has(cur, name)) {
-      value <- env_get(cur, name)
+    candidate <- env_get(cur, name, default = sentinel)
+    if (!is_missing_sentinel(candidate)) {
+      value <- candidate
       break
     }
     cur <- env_parent(cur)
@@ -456,6 +458,16 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
   )
 
   value
+}
+
+is_missing_sentinel <- function(x) {
+  inherits(x, "tidyselect:::missing_sentinel")
+}
+missing_sentinel <- function() {
+  # Much faster than `structure()`
+  out <- list()
+  class(out) <- "tidyselect:::missing_sentinel"
+  out
 }
 
 validate_dot_data <- function(expr, call) {


### PR DESCRIPTION
Another minor performance improvement, this one related to `eval_sym()`, which should affect most tidyselect calls.

This is actually related to https://github.com/r-lib/rlang/issues/1582, where not supplying a `default` ends up being super slow. We could wait for that fix, but specifying the `default` in the meantime like this would also help

```r
library(tidyselect)
library(rlang)

expr <- expr(c(mpg, cyl))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)      1ms   1.28ms      769.    5.37MB     11.3

# PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    963µs   1.14ms      867.    5.91MB     12.7


expr <- expr(mpg)
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    646µs    827µs     1175.    7.07KB     12.0

# PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    639µs    728µs     1346.    7.07KB     13.9
```