### PR TITLE
Replace homegrown set operations with vctrs versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     glue (>= 1.3.0),
     lifecycle (>= 1.0.3),
     rlang (>= 1.0.4),
-    vctrs (>= 0.5.0),
+    vctrs (>= 0.5.2),
     withr
 Suggests:
     covr,

--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -250,7 +250,7 @@ as_indices_impl <- function(x, vars, strict, call = caller_env(), arg = NULL) {
     # Remove out-of-bounds elements if non-strict. We do this eagerly
     # because names vectors must be converted to locations here.
     x <- switch(typeof(x),
-      character = set_intersect(x, c(vars, na_chr)),
+      character = vctrs::vec_set_intersect(x, c(vars, na_chr)),
       double = ,
       integer = x[x <= length(vars)],
       x

--- a/R/sets.R
+++ b/R/sets.R
@@ -3,16 +3,16 @@
 # unnamed elements matching named ones
 sel_union <- function(x, y) {
   if (any_valid_names(names(x)) || any_valid_names(names(y))) {
-    sel_operation(x, y, set_union)
+    sel_operation(x, y, vctrs::vec_set_union)
   } else {
-    set_union(x, y)
+    vctrs::vec_set_union(x, y)
   }
 }
 sel_intersect <- function(x, y) {
   if (any_valid_names(names(x)) || any_valid_names(names(y))) {
-    sel_operation(x, y, set_intersect)
+    sel_operation(x, y, vctrs::vec_set_intersect)
   } else {
-    set_intersect(x, y)
+    vctrs::vec_set_intersect(x, y)
   }
 }
 sel_unique <- function(x) {
@@ -33,9 +33,9 @@ sel_diff <- function(x, y, vars = NULL, error_call = caller_env()) {
     y <- loc_validate(y, vars, call = error_call)
   }
   if (any_valid_names(names(x)) && any_valid_names(names(y))) {
-    sel_operation(x, y, set_diff)
+    sel_operation(x, y, vctrs::vec_set_difference)
   } else {
-    set_diff(x, y)
+    vctrs::vec_set_difference(x, y)
   }
 }
 sel_complement <- function(x, vars = NULL, error_call = caller_env()) {
@@ -72,19 +72,4 @@ propagate_names <- function(x, from = NULL) {
   x$names[unnamed][matches != 0L] <- from$names[matches]
 
   x
-}
-
-# https://github.com/r-lib/vctrs/issues/548
-set_diff <- function(x, y) {
-  vctrs::vec_unique(vctrs::vec_slice(x, !vctrs::vec_in(x, y)))
-}
-set_intersect <- function(x, y) {
-  pos <- vctrs::vec_match(y, x)
-  pos <- vctrs::vec_unique(pos)
-  pos <- vctrs::vec_sort(pos)
-  pos <- pos[!is.na(pos)]
-  vctrs::vec_slice(x, pos)
-}
-set_union <- function(x, y) {
-  vctrs::vec_unique(vctrs::vec_c(x, y))
 }


### PR DESCRIPTION
Not sure that this one really has that much performance impact in the most common cases, but I do think it probably starts to help more once you have more complex expressions with multiple calls to `set_*()`

```r
library(tidyselect)
library(rlang)

expr <- expr(c(mpg, cyl))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)      1ms   1.27ms      774.    5.37MB     11.5

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    968µs   1.24ms      801.     5.9MB     12.1

expr <- expr(mpg)
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    646µs    816µs     1230.    7.07KB     12.7

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    629µs    720µs     1333.    7.07KB     14.1

expr <- expr(starts_with("d") & where(is.numeric))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    961µs   1.24ms      791.     211KB     12.9

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    910µs   1.14ms      881.     231KB     14.2

expr <- expr(starts_with("d") & !where(is.numeric))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# CRAN
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)   1.03ms   1.34ms      730.      79KB     12.8

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    975µs   1.23ms      806.    93.5KB     13.9
```