### PR TITLE
Use `withCallingHandlers()` over `try_fetch()` for performance

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,5 +1,5 @@
 with_subscript_errors <- function(expr, type = "select") {
-  try_fetch(
+  withCallingHandlers(
     expr,
     vctrs_error_subscript = function(cnd) {
       cnd$subscript_action <- subscript_action(type)
@@ -10,7 +10,7 @@ with_subscript_errors <- function(expr, type = "select") {
 }
 
 with_chained_errors <- function(expr, action, call, eval_expr = NULL) {
-  try_fetch(
+  withCallingHandlers(
     expr,
     error = function(cnd) {
       eval_expr <- quo_squash(eval_expr)

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -181,7 +181,7 @@ eval_relocate <- function(expr,
 }
 
 with_rename_errors <- function(expr, arg, error_call) {
-  try_fetch(
+  withCallingHandlers(
     expr,
     `tidyselect:::error_disallowed_rename` = function(cnd) {
       cli::cli_abort(

--- a/tests/testthat/_snaps/eval-select.md
+++ b/tests/testthat/_snaps/eval-select.md
@@ -98,10 +98,10 @@
       ---
       Backtrace:
         1. base::print(expect_error(select_loc(mtcars, f(base = TRUE))))
-       25. tidyselect (local) f(base = TRUE)
-       26. tidyselect (local) g(base)
-       27. tidyselect (local) h(base)
-       28. base::stop("foo")
+       19. tidyselect (local) f(base = TRUE)
+       20. tidyselect (local) g(base)
+       21. tidyselect (local) h(base)
+       22. base::stop("foo")
     Code
       print(expect_error(select_loc(mtcars, f(base = FALSE))))
     Output
@@ -113,9 +113,9 @@
       ---
       Backtrace:
         1. base::print(expect_error(select_loc(mtcars, f(base = FALSE))))
-       25. tidyselect (local) f(base = FALSE)
-       26. tidyselect (local) g(base)
-       27. tidyselect (local) h(base)
+       19. tidyselect (local) f(base = FALSE)
+       20. tidyselect (local) g(base)
+       21. tidyselect (local) h(base)
 
 # eval_select() produces correct chained errors
 

--- a/tests/testthat/_snaps/vars-pull.md
+++ b/tests/testthat/_snaps/vars-pull.md
@@ -111,10 +111,10 @@
       ---
       Backtrace:
         1. base::print(expect_error(vars_pull(letters, f(base = TRUE))))
-       17. tidyselect (local) f(base = TRUE)
-       18. tidyselect (local) g(base)
-       19. tidyselect (local) h(base)
-       20. base::stop("foo")
+       12. tidyselect (local) f(base = TRUE)
+       13. tidyselect (local) g(base)
+       14. tidyselect (local) h(base)
+       15. base::stop("foo")
     Code
       print(expect_error(vars_pull(letters, f(base = FALSE))))
     Output
@@ -126,7 +126,7 @@
       ---
       Backtrace:
         1. base::print(expect_error(vars_pull(letters, f(base = FALSE))))
-       17. tidyselect (local) f(base = FALSE)
-       18. tidyselect (local) g(base)
-       19. tidyselect (local) h(base)
+       12. tidyselect (local) f(base = FALSE)
+       13. tidyselect (local) g(base)
+       14. tidyselect (local) h(base)
 


### PR DESCRIPTION
Probably my last tidyselect micro-optimization

Motivation is that `try_fetch()` is slower than `withCallingHandlers()` and we aren't using any special `try_fetch()` behavior here:

``` r
bench::mark(
  rlang = try_fetch(1, error = function(cnd) stop("oh no")),
  base = withCallingHandlers(1, error = function(cnd) stop("oh no"))
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rlang       14.01µs  15.97µs    60353.        0B     18.1
#> 2 base         1.93µs   2.59µs   382351.        0B     38.2
```

It does change the backtrace _numbers_ a little but that seems ok?

I know `with_subscript_errors()` is always called at least 1 time per `eval_select()` call, and `with_chained_errors()` is called 3 times with the below call, so this ends up adding up to a handful of microseconds:

``` r
library(tidyselect)
library(rlang)

expr <- expr(starts_with("d") | starts_with("m") | starts_with("v"))
bench::mark(eval_select(expr, mtcars), iterations = 50000)

# Dev tidyselect
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    831µs   1.11ms      881.    5.25MB     11.0

# This PR
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_select(expr, mtcars)    803µs   1.04ms      951.    5.72MB     11.0
```

Which become a little bit more convincing if you just look at a system time result of 10,000 calls:

```r
library(tidyselect)
library(rlang)
expr <- expr(starts_with("d") | starts_with("m") | starts_with("v"))

# dev tidyselect (run twice)
system.time(for(i in 1:10000) eval_select(expr, mtcars))
#>   user  system elapsed 
#>  9.903   0.055   9.988 
system.time(for(i in 1:10000) eval_select(expr, mtcars))
#>   user  system elapsed 
#>  9.737   0.050   9.820 


# this PR (run twice)
system.time(for(i in 1:10000) eval_select(expr, mtcars))
#>   user  system elapsed 
#>  9.027   0.051   9.106 
system.time(for(i in 1:10000) eval_select(expr, mtcars))
#>    user  system elapsed 
#>  9.255   0.053   9.339 
```