### PR TITLE
Avoid nested `expect_error()` in snapshot tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     magrittr,
     rmarkdown,
     stringr,
-    testthat (>= 3.1.1),
+    testthat (>= 3.2.1),
     tibble (>= 2.1.3)
 VignetteBuilder:
     knitr

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -18,31 +18,27 @@
 # can't relocate with out-of-bounds variables by default
 
     Code
-      (expect_error(relocate_loc(x, c)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, c)
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't relocate columns that don't exist.
       x Column `c` doesn't exist.
     Code
-      (expect_error(relocate_loc(x, c(1, 3))))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, c(1, 3))
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't relocate columns that don't exist.
       i Location 3 doesn't exist.
       i There are only 2 columns.
     Code
-      (expect_error(relocate_loc(x, a, before = c)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, a, before = c)
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
     Code
-      (expect_error(relocate_loc(x, a, after = c)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, a, after = c)
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
@@ -50,16 +46,14 @@
 # can relocate with out-of-bounds variables in `expr` if `strict = FALSE`
 
     Code
-      (expect_error(relocate_loc(x, a, before = c, strict = FALSE)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, a, before = c, strict = FALSE)
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
     Code
-      (expect_error(relocate_loc(x, a, after = c, strict = FALSE)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      relocate_loc(x, a, after = c, strict = FALSE)
+    Condition <vctrs_error_subscript_oob>
       Error in `relocate_loc()`:
       ! Can't select columns that don't exist.
       x Column `c` doesn't exist.
@@ -67,36 +61,31 @@
 # can forbid rename syntax
 
     Code
-      (expect_error(relocate_loc(x, c(foo = b), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      relocate_loc(x, c(foo = b), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
     Code
-      (expect_error(relocate_loc(x, c(b, foo = b), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      relocate_loc(x, c(b, foo = b), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `relocate_loc()`:
       ! Can't rename variables in this context.
 
 # can forbid empty selections
 
     Code
-      (expect_error(relocate_loc(x, allow_empty = FALSE, error_arg = "...")))
-    Output
-      <error/tidyselect_error_empty_selection>
+      relocate_loc(x, allow_empty = FALSE, error_arg = "...")
+    Condition
       Error in `relocate_loc()`:
       ! `...` must select at least one column.
     Code
-      (expect_error(relocate_loc(mtcars, integer(), allow_empty = FALSE)))
-    Output
-      <error/tidyselect_error_empty_selection>
+      relocate_loc(mtcars, integer(), allow_empty = FALSE)
+    Condition
       Error in `relocate_loc()`:
       ! Must select at least one item.
     Code
-      (expect_error(relocate_loc(mtcars, starts_with("z"), allow_empty = FALSE)))
-    Output
-      <error/tidyselect_error_empty_selection>
+      relocate_loc(mtcars, starts_with("z"), allow_empty = FALSE)
+    Condition
       Error in `relocate_loc()`:
       ! Must select at least one item.
 
@@ -116,27 +105,23 @@
 # `before` and `after` forbid renaming
 
     Code
-      (expect_error(relocate_loc(x, b, before = c(new = c))))
-    Output
-      <error/rlang_error>
+      relocate_loc(x, b, before = c(new = c))
+    Condition <rlang_error>
       Error in `relocate_loc()`:
       ! Can't rename variables when `before` is supplied.
     Code
-      (expect_error(relocate_loc(x, b, before = c(new = c), before_arg = ".before")))
-    Output
-      <error/rlang_error>
+      relocate_loc(x, b, before = c(new = c), before_arg = ".before")
+    Condition <rlang_error>
       Error in `relocate_loc()`:
       ! Can't rename variables when `.before` is supplied.
     Code
-      (expect_error(relocate_loc(x, b, after = c(new = c))))
-    Output
-      <error/rlang_error>
+      relocate_loc(x, b, after = c(new = c))
+    Condition <rlang_error>
       Error in `relocate_loc()`:
       ! Can't rename variables when `after` is supplied.
     Code
-      (expect_error(relocate_loc(x, b, after = c(new = c), after_arg = ".after")))
-    Output
-      <error/rlang_error>
+      relocate_loc(x, b, after = c(new = c), after_arg = ".after")
+    Condition <rlang_error>
       Error in `relocate_loc()`:
       ! Can't rename variables when `.after` is supplied.
 

--- a/tests/testthat/_snaps/eval-select.md
+++ b/tests/testthat/_snaps/eval-select.md
@@ -2,49 +2,42 @@
 
     Code
       x <- list(a = 1, b = 2, c = 3)
-      (expect_error(select_loc(x, "a", include = 1)))
-    Output
-      <error/rlang_error>
+      select_loc(x, "a", include = 1)
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! `include` must be a character vector.
     Code
-      (expect_error(select_loc(x, "a", include = "d")))
-    Output
-      <error/rlang_error>
+      select_loc(x, "a", include = "d")
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! `include` must only include variables found in `data`.
       i Unknown variables: d
     Code
-      (expect_error(select_loc(x, "a", exclude = 1)))
-    Output
-      <error/rlang_error>
+      select_loc(x, "a", exclude = 1)
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! `include` must be a character vector.
 
 # can forbid rename syntax (#178)
 
     Code
-      (expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
     Code
-      (expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
     Code
-      (expect_error(select_loc(mtcars, c(cyl, foo = mpg), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      select_loc(mtcars, c(cyl, foo = mpg), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
     Code
-      (expect_error(select_loc(mtcars, c(foo = mpg, cyl), allow_rename = FALSE)))
-    Output
-      <error/tidyselect:::error_disallowed_rename>
+      select_loc(mtcars, c(foo = mpg, cyl), allow_rename = FALSE)
+    Condition <tidyselect:::error_disallowed_rename>
       Error in `select_loc()`:
       ! Can't rename variables in this context.
 
@@ -87,9 +80,8 @@
 # eval_select() errors mention correct calls
 
     Code
-      (expect_error(select_loc(mtcars, f())))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, f())
+    Condition <rlang_error>
       Error in `select_loc()`:
       Caused by error in `f()`:
       ! foo
@@ -97,9 +89,8 @@
 # predicate outputs are type-checked
 
     Code
-      (expect_error(select_loc(mtcars, function(x) "")))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, function(x) "")
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Predicate must return `TRUE` or `FALSE`, not `""`.
 
@@ -174,18 +165,16 @@
 # eval_select() produces correct chained errors
 
     Code
-      (expect_error(select_loc(mtcars, 1 + "")))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, 1 + "")
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       f <- (function() 1 + "")
-      (expect_error(select_loc(mtcars, f())))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, f())
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `f()`.
       Caused by error in `1 + ""`:

--- a/tests/testthat/_snaps/eval-walk.md
+++ b/tests/testthat/_snaps/eval-walk.md
@@ -83,10 +83,9 @@
       Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.
       i Please use `all_of(var)` (or `any_of(var)`) instead of `.data[[var]]`
 
-# eval_walk() has informative messages
+# eval_walk() warns when using a predicate without where()
 
     Code
-      # Using a predicate without where() warns
       invisible(select_loc(iris, is_integer))
     Condition
       Warning:
@@ -131,11 +130,12 @@
       
         # Now:
         data %>% select(where(is_integer))
+
+# eval_walk() errors when formula shorthand are not wrapped
+
     Code
-      # formula shorthand must be wrapped
-      (expect_error(select_loc(mtcars, ~ is.numeric(.x))))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, ~ is.numeric(.x))
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Formula shorthand must be wrapped in `where()`.
       
@@ -145,10 +145,8 @@
         # Good
         data %>% select(where(~is.numeric(.x)))
     Code
-      (expect_error(select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) ||
-        is.character(.x))))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x))
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Formula shorthand must be wrapped in `where()`.
       
@@ -158,10 +156,9 @@
         # Good
         data %>% select(where(~is.numeric(.x) || is.factor(.x) || is.character(.x)))
     Code
-      (expect_error(select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) ||
-        is.character(.x) || is.numeric(.x) || is.factor(.x) || is.character(.x))))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x) ||
+        is.numeric(.x) || is.factor(.x) || is.character(.x))
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Formula shorthand must be wrapped in `where()`.
       
@@ -171,9 +168,8 @@
         # Good
         data %>% select(where(~...))
     Code
-      (expect_error(select_loc(mtcars, .data$"foo")))
-    Output
-      <error/rlang_error>
+      select_loc(mtcars, .data$"foo")
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! The RHS of `.data$rhs` must be a symbol.
 

--- a/tests/testthat/_snaps/helpers-vector.md
+++ b/tests/testthat/_snaps/helpers-vector.md
@@ -12,48 +12,42 @@
 # all_of() and any_of() check their inputs
 
     Code
-      (expect_error(select_loc(letters2, all_of(NA))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, all_of(NA))
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Selections can't have missing values.
     Code
-      (expect_error(select_loc(letters2, any_of(NA))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, any_of(NA))
+    Condition <rlang_error>
       Error in `select_loc()`:
       ! Selections can't have missing values.
     Code
-      (expect_error(select_loc(letters2, all_of(TRUE))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, all_of(TRUE))
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `all_of(TRUE)`.
       Caused by error in `all_of()`:
       ! Can't subset elements.
       x Subscript must be numeric or character, not `TRUE`.
     Code
-      (expect_error(select_loc(letters2, any_of(TRUE))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, any_of(TRUE))
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `any_of(TRUE)`.
       Caused by error in `any_of()`:
       ! Can't subset elements.
       x Subscript must be numeric or character, not `TRUE`.
     Code
-      (expect_error(select_loc(letters2, any_of(is.factor))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, any_of(is.factor))
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `any_of(is.factor)`.
       Caused by error in `any_of()`:
       ! Can't subset elements.
       x Subscript must be numeric or character, not a function.
     Code
-      (expect_error(select_loc(letters2, all_of(is.factor))))
-    Output
-      <error/rlang_error>
+      select_loc(letters2, all_of(is.factor))
+    Condition <rlang_error>
       Error in `select_loc()`:
       i In argument: `all_of(is.factor)`.
       Caused by error in `all_of()`:
@@ -63,9 +57,8 @@
 # any_of() errors out of context
 
     Code
-      (expect_error(any_of()))
-    Output
-      <error/rlang_error>
+      any_of()
+    Condition <rlang_error>
       Error:
       ! `any_of()` must be used within a *selecting* function.
       i See <https://tidyselect.r-lib.org/reference/faq-selection-context.html> for details.

--- a/tests/testthat/_snaps/helpers.md
+++ b/tests/testthat/_snaps/helpers.md
@@ -1,10 +1,8 @@
 # one_of gives useful errors
 
     Code
-      (expect_error(one_of(1L, .vars = c("x", "y")), class = "vctrs_error_incompatible_index_type")
-      )
-    Output
-      <error/vctrs_error_incompatible_index_type>
+      one_of(1L, .vars = c("x", "y"))
+    Condition <vctrs_error_incompatible_index_type>
       Error in `one_of()`:
       ! Input 1 must be a vector of column names, not an integer.
 

--- a/tests/testthat/_snaps/vars-pull.md
+++ b/tests/testthat/_snaps/vars-pull.md
@@ -79,22 +79,19 @@
       Error in `f()`:
       ! `var` is absent but must be supplied.
 
-# vars_pull() has informative errors
+# vars_pull() are base errors
 
     Code
-      # # vars_pull() instruments base errors
-      (expect_error(vars_pull(letters, foobar), ""))
-    Output
-      <error/rlang_error>
+      vars_pull(letters, foobar)
+    Condition <rlang_error>
       Error:
       ! object 'foobar' not found
 
 # vars_pull() errors mention correct calls
 
     Code
-      (expect_error(vars_pull(letters, f())))
-    Output
-      <error/rlang_error>
+      vars_pull(letters, f())
+    Condition <rlang_error>
       Error in `f()`:
       ! foo
 

--- a/tests/testthat/test-eval-relocate.R
+++ b/tests/testthat/test-eval-relocate.R
@@ -128,11 +128,11 @@ test_that("can't supply both `before` and `after`", {
 test_that("can't relocate with out-of-bounds variables by default", {
   x <- c(a = 1, b = 2)
 
-  expect_snapshot({
-    (expect_error(relocate_loc(x, c)))
-    (expect_error(relocate_loc(x, c(1, 3))))
-    (expect_error(relocate_loc(x, a, before = c)))
-    (expect_error(relocate_loc(x, a, after = c)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    relocate_loc(x, c)
+    relocate_loc(x, c(1, 3))
+    relocate_loc(x, a, before = c)
+    relocate_loc(x, a, after = c)
   })
 })
 
@@ -143,9 +143,9 @@ test_that("can relocate with out-of-bounds variables in `expr` if `strict = FALS
   expect_identical(relocate_loc(x, c(d = b, e = c), strict = FALSE), c(d = 2L, a = 1L))
 
   # But still not with OOB variables in `before` or `after`
-  expect_snapshot({
-    (expect_error(relocate_loc(x, a, before = c, strict = FALSE)))
-    (expect_error(relocate_loc(x, a, after = c, strict = FALSE)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    relocate_loc(x, a, before = c, strict = FALSE)
+    relocate_loc(x, a, after = c, strict = FALSE)
   })
 })
 
@@ -165,9 +165,9 @@ test_that("accepts name spec", {
 test_that("can forbid rename syntax", {
   x <- c(a = 1, b = 2, c = 3)
 
-  expect_snapshot({
-    (expect_error(relocate_loc(x, c(foo = b), allow_rename = FALSE)))
-    (expect_error(relocate_loc(x, c(b, foo = b), allow_rename = FALSE)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    relocate_loc(x, c(foo = b), allow_rename = FALSE)
+    relocate_loc(x, c(b, foo = b), allow_rename = FALSE)
   })
 
   expect_named(relocate_loc(x, c(c, b), allow_rename = FALSE), c("c", "b", "a"))
@@ -176,32 +176,32 @@ test_that("can forbid rename syntax", {
 test_that("can forbid empty selections", {
   x <- c(a = 1, b = 2, c = 3)
 
-  expect_snapshot({
-    (expect_error(relocate_loc(x, allow_empty = FALSE, error_arg = "...")))
-    (expect_error(relocate_loc(mtcars, integer(), allow_empty = FALSE)))
-    (expect_error(relocate_loc(mtcars, starts_with("z"), allow_empty = FALSE)))
+  expect_snapshot(error = TRUE, {
+    relocate_loc(x, allow_empty = FALSE, error_arg = "...")
+    
+    relocate_loc(mtcars, integer(), allow_empty = FALSE)
+    relocate_loc(mtcars, starts_with("z"), allow_empty = FALSE)
   })
 })
 
 test_that("can forbid empty selections", {
   x <- c(a = 1, b = 2, c = 3)
   
-  expect_snapshot(
-    error = TRUE, {
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     relocate_loc(mtcars, before = integer(), allow_empty = FALSE)
     relocate_loc(mtcars, starts_with("z"), allow_empty = FALSE)
-  }, cnd_class = TRUE)
+  })
 })
 
 
 test_that("`before` and `after` forbid renaming", {
   x <- c(a = 1, b = 2, c = 3)
 
-  expect_snapshot({
-    (expect_error(relocate_loc(x, b, before = c(new = c))))
-    (expect_error(relocate_loc(x, b, before = c(new = c), before_arg = ".before")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    relocate_loc(x, b, before = c(new = c))
+    relocate_loc(x, b, before = c(new = c), before_arg = ".before")
 
-    (expect_error(relocate_loc(x, b, after = c(new = c))))
-    (expect_error(relocate_loc(x, b, after = c(new = c), after_arg = ".after")))
+    relocate_loc(x, b, after = c(new = c))
+    relocate_loc(x, b, after = c(new = c), after_arg = ".after")
   })
 })

--- a/tests/testthat/test-eval-select.R
+++ b/tests/testthat/test-eval-select.R
@@ -53,11 +53,11 @@ test_that("included variables added to front", {
 })
 
 test_that("include and exclude validate their inputs", {
-  expect_snapshot({
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     x <- list(a = 1, b = 2, c = 3)
-    (expect_error(select_loc(x, "a", include = 1)))
-    (expect_error(select_loc(x, "a", include = "d")))
-    (expect_error(select_loc(x, "a", exclude = 1)))
+    select_loc(x, "a", include = 1)
+    select_loc(x, "a", include = "d")
+    select_loc(x, "a", exclude = 1)
   })
 })
 
@@ -87,11 +87,11 @@ test_that("result is named even with constant inputs (#173)", {
 })
 
 test_that("can forbid rename syntax (#178)", {
-  expect_snapshot({
-    (expect_error(select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)))
-    (expect_error(select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)))
-    (expect_error(select_loc(mtcars, c(cyl, foo = mpg), allow_rename = FALSE)))
-    (expect_error(select_loc(mtcars, c(foo = mpg, cyl), allow_rename = FALSE)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    select_loc(mtcars, c(foo = cyl), allow_rename = FALSE)
+    select_loc(mtcars, c(cyl, foo = cyl), allow_rename = FALSE)
+    select_loc(mtcars, c(cyl, foo = mpg), allow_rename = FALSE)
+    select_loc(mtcars, c(foo = mpg, cyl), allow_rename = FALSE)
   })
 
   expect_named(select_loc(mtcars, starts_with("c") | all_of("am"), allow_rename = FALSE), c("cyl", "carb", "am"))
@@ -115,13 +115,11 @@ test_that("can forbid empty selections with informative error", {
 
 test_that("eval_select() errors mention correct calls", {
   f <- function() stop("foo")
-  expect_snapshot((expect_error(select_loc(mtcars, f()))))
+  expect_snapshot(select_loc(mtcars, f()), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("predicate outputs are type-checked", {
-  expect_snapshot({
-    (expect_error(select_loc(mtcars, function(x) "")))
-  })
+  expect_snapshot(select_loc(mtcars, function(x) ""), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("eval_select() produces correct backtraces", {
@@ -130,7 +128,7 @@ test_that("eval_select() produces correct backtraces", {
   h <- function(base) if (base) stop("foo") else abort("foo")
 
   local_options(
-    rlang_trace_trop_env = current_env(),
+    rlang_trace_top_env = current_env(),
     rlang_trace_format_srcrefs = FALSE
   )
 
@@ -141,11 +139,11 @@ test_that("eval_select() produces correct backtraces", {
 })
 
 test_that("eval_select() produces correct chained errors", {
-  expect_snapshot({
-    (expect_error(select_loc(mtcars, 1 + "")))
-
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    select_loc(mtcars, 1 + "")
+    
     f <- function() 1 + ""
-    (expect_error(select_loc(mtcars, f())))
+    select_loc(mtcars, f())
   })
 })
 

--- a/tests/testthat/test-eval-walk.R
+++ b/tests/testthat/test-eval-walk.R
@@ -249,7 +249,7 @@ test_that(".data in env-expression has the lexical definition", {
     .data <- mtcars
     quo({ stopifnot(identical(.data, mtcars)); NULL})
   })
-  expect_error(select_loc(mtcars, !!quo), regexp = NA)
+  expect_no_error(select_loc(mtcars, !!quo))
 })
 
 test_that("binary `/` is short for set difference", {
@@ -260,8 +260,6 @@ test_that("binary `/` is short for set difference", {
 })
 
 test_that("can select names with unrepresentable characters", {
-  skip_if_not_installed("rlang", "0.4.2.9000")
-
   # R now emits a warning when converting to symbol. Since Windows
   # gained UTF-8 support, supporting unrepresentable characters is no
   # longer necessary.
@@ -301,23 +299,23 @@ test_that("eval_sym() still supports predicate functions starting with `is`", {
   expect_identical(select_loc(iris, isTRUE), select_loc(iris, where(isTRUE)))
 })
 
-test_that("eval_walk() has informative messages", {
+test_that("eval_walk() warns when using a predicate without where()", {
   expect_snapshot({
-    "Using a predicate without where() warns"
     invisible(select_loc(iris, is_integer))
     invisible(select_loc(iris, is.numeric))
     invisible(select_loc(iris, isTRUE))
-
     "Warning is not repeated"
     invisible(select_loc(iris, is_integer))
+  })
+})
 
-    "formula shorthand must be wrapped"
-    (expect_error(select_loc(mtcars, ~ is.numeric(.x))))
-    (expect_error(select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x))))
-    (expect_error(select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x) ||
-                                       is.numeric(.x) || is.factor(.x) || is.character(.x))))
-
-    (expect_error(select_loc(mtcars, .data$"foo")))
+test_that("eval_walk() errors when formula shorthand are not wrapped", {
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    select_loc(mtcars, ~ is.numeric(.x))
+    select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x))
+    select_loc(mtcars, ~ is.numeric(.x) || is.factor(.x) || is.character(.x) ||
+                               is.numeric(.x) || is.factor(.x) || is.character(.x))
+    select_loc(mtcars, .data$"foo")
   })
 })
 

--- a/tests/testthat/test-helpers-vector.R
+++ b/tests/testthat/test-helpers-vector.R
@@ -38,22 +38,20 @@ test_that("any_of() is lax", {
 })
 
 test_that("all_of() and any_of() check their inputs", {
-  expect_snapshot({
-    (expect_error(select_loc(letters2, all_of(NA))))
-    (expect_error(select_loc(letters2, any_of(NA))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    select_loc(letters2, all_of(NA))
+    select_loc(letters2, any_of(NA))
 
-    (expect_error(select_loc(letters2, all_of(TRUE))))
-    (expect_error(select_loc(letters2, any_of(TRUE))))
+    select_loc(letters2, all_of(TRUE))
+    select_loc(letters2, any_of(TRUE))
 
-    (expect_error(select_loc(letters2, any_of(is.factor))))
-    (expect_error(select_loc(letters2, all_of(is.factor))))
+    select_loc(letters2, any_of(is.factor))
+    select_loc(letters2, all_of(is.factor))
   })
 })
 
 test_that("any_of() errors out of context", {
-  expect_snapshot({
-    (expect_error(any_of()))
-  })
+  expect_snapshot(any_of(), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("all_of() is deprecated out of context (#269)", {

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,10 +1,7 @@
 
 test_that("one_of gives useful errors", {
-  expect_snapshot({
-    (expect_error(
-      one_of(1L, .vars = c("x", "y")),
-      class = "vctrs_error_incompatible_index_type"
-    ))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    one_of(1L, .vars = c("x", "y"))
   })
 })
 

--- a/tests/testthat/test-vars-pull.R
+++ b/tests/testthat/test-vars-pull.R
@@ -98,16 +98,13 @@ test_that("can pull with negative values", {
   expect_identical(vars_pull(letters, -3), "x")
 })
 
-test_that("vars_pull() has informative errors", {
-  expect_snapshot({
-    "# vars_pull() instruments base errors"
-    (expect_error(vars_pull(letters, foobar), ""))
-  })
+test_that("vars_pull() are base errors", {
+  expect_snapshot(vars_pull(letters, foobar), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("vars_pull() errors mention correct calls", {
   f <- function() stop("foo")
-  expect_snapshot((expect_error(vars_pull(letters, f()))))
+  expect_snapshot(vars_pull(letters, f()), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("vars_pull() produces correct backtraces", {
@@ -116,7 +113,7 @@ test_that("vars_pull() produces correct backtraces", {
   h <- function(base) if (base) stop("foo") else abort("foo")
 
   local_options(
-    rlang_trace_trop_env = current_env(),
+    rlang_trace_top_env = current_env(),
     rlang_trace_format_srcrefs = FALSE
   )
 


### PR DESCRIPTION
I guess the goal was to have the class of the error.

This PR uses the `cnd_class` argument from `expect_snapshot()` instead.

I decided to use 

```r
expect_snapshot(error = TRUE, cnd_class = TRUE, {
  code
})
```

to avoid having a large diff if it is decided the condition class is no longer important in certain tests.

