### PR TITLE
fixup error msg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,11 +21,6 @@
   In addition, it gains a `cross` argument that allows you to take the
   cartesian product of these arguments instead.
 
-* `eval_select(allow_empty = FALSE)` gains a new argument to yield a better error
-  message in case of empty selection (@olivroy, #327)
-
-* `eval_select()` and `eval_relocate()` gain a new `error_arg` argument that can be specified to throw a better error message when `allow_empty = FALSE`.
-
 * `eval_select()` and `eval_relocate()` throw a classed error message when `allow_empty = FALSE` (@olivroy, #347).
 
 # tidyselect 1.2.1

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -185,7 +185,7 @@ eval_relocate <- function(expr,
 with_rename_errors <- function(expr, arg, error_call) {
   withCallingHandlers(
     expr,
-    `tidyselect:::error_disallowed_rename` = function(cnd) {
+    `tidyselect_error_cannot_rename` = function(cnd) {
       cli::cli_abort(
         "Can't rename variables when {.arg {arg}} is supplied.",
         call = error_call

--- a/R/eval-relocate.R
+++ b/R/eval-relocate.R
@@ -117,17 +117,14 @@ eval_relocate <- function(expr,
   }
 
   if (has_before) {
-    where <- with_rename_errors(
-      eval_select(
-        expr = before,
-        data = data,
-        env = env,
-        error_call = error_call,
-        allow_predicates = allow_predicates,
-        allow_rename = FALSE
-      ),
-      arg = before_arg,
-      error_call = error_call
+    where <- eval_select(
+      expr = before,
+      data = data,
+      env = env,
+      error_call = error_call,
+      allow_predicates = allow_predicates,
+      allow_rename = FALSE,
+      error_arg = before_arg
     )
     where <- unname(where)
 
@@ -138,17 +135,14 @@ eval_relocate <- function(expr,
       where <- min(where)
     }
   } else if (has_after) {
-    where <- with_rename_errors(
-      eval_select(
-        expr = after,
-        data = data,
-        env = env,
-        error_call = error_call,
-        allow_predicates = allow_predicates,
-        allow_rename = FALSE
-      ),
-      arg = after_arg,
-      error_call = error_call
+    where <- eval_select(
+      expr = after,
+      data = data,
+      env = env,
+      error_call = error_call,
+      allow_predicates = allow_predicates,
+      allow_rename = FALSE,
+      error_arg = after_arg
     )
     where <- unname(where)
 
@@ -180,16 +174,4 @@ eval_relocate <- function(expr,
   sel <- vctrs::vec_c(lhs, sel, rhs)
 
   sel
-}
-
-with_rename_errors <- function(expr, arg, error_call) {
-  withCallingHandlers(
-    expr,
-    `tidyselect_error_cannot_rename` = function(cnd) {
-      cli::cli_abort(
-        "Can't rename variables when {.arg {arg}} is supplied.",
-        call = error_call
-      )
-    }
-  )
 }

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -112,22 +112,22 @@
 
     Code
       relocate_loc(x, b, before = c(new = c))
-    Condition <tidyselect_error_cannot_rename>
+    Condition <rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when `before` is supplied.
     Code
       relocate_loc(x, b, before = c(new = c), before_arg = ".before")
-    Condition <tidyselect_error_cannot_rename>
+    Condition <rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when `.before` is supplied.
     Code
       relocate_loc(x, b, after = c(new = c))
-    Condition <tidyselect_error_cannot_rename>
+    Condition <rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when `after` is supplied.
     Code
       relocate_loc(x, b, after = c(new = c), after_arg = ".after")
-    Condition <tidyselect_error_cannot_rename>
+    Condition <rlang_error>
       Error in `relocate_loc()`:
-      ! Can't rename variables in this context.
+      ! Can't rename variables when `.after` is supplied.
 

--- a/tests/testthat/_snaps/eval-relocate.md
+++ b/tests/testthat/_snaps/eval-relocate.md
@@ -112,22 +112,26 @@
 
     Code
       relocate_loc(x, b, before = c(new = c))
-    Condition <rlang_error>
+    Condition <tidyselect_error_cannot_rename>
       Error in `relocate_loc()`:
-      ! Can't rename variables when `before` is supplied.
+      ! Can't rename variables in this context.
+      i In argument: `before`.
     Code
       relocate_loc(x, b, before = c(new = c), before_arg = ".before")
-    Condition <rlang_error>
+    Condition <tidyselect_error_cannot_rename>
       Error in `relocate_loc()`:
-      ! Can't rename variables when `.before` is supplied.
+      ! Can't rename variables in this context.
+      i In argument: `.before`.
     Code
       relocate_loc(x, b, after = c(new = c))
-    Condition <rlang_error>
+    Condition <tidyselect_error_cannot_rename>
       Error in `relocate_loc()`:
-      ! Can't rename variables when `after` is supplied.
+      ! Can't rename variables in this context.
+      i In argument: `after`.
     Code
       relocate_loc(x, b, after = c(new = c), after_arg = ".after")
-    Condition <rlang_error>
+    Condition <tidyselect_error_cannot_rename>
       Error in `relocate_loc()`:
-      ! Can't rename variables when `.after` is supplied.
+      ! Can't rename variables in this context.
+      i In argument: `.after`.
 


### PR DESCRIPTION
Also remove duplicate news items (it is already on line 15)

Noted that `with_rename_error()` is no longer needed as using `eval_select()` with `error_arg` does the job (better?)